### PR TITLE
docs: Update README version to 0.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.10.2
+## Version 0.10.4
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,8 +37,8 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.10.2 Enhancement
-- **SDN Configuration Redesign**: Step 18 now starts with Enable SDN / No SDN selection. SDN features only shown when enabled. Clearer flow since SDN is optional and not in ARM templates.
+### 🎉 Version 0.10.4 Enhancement
+- **Single-Node Storage Intent Support**: Single-node clusters now support all storage intent options. Non-low-capacity single-node requires 2 RDMA ports; Low Capacity keeps RDMA optional.
 
 ### 🎉 Version 0.10.1 Bug Fix
 - **ARM Import Options Dialog**: When importing ARM templates, a dialog now prompts for settings not included in ARM templates: Arc Gateway, Enterprise Proxy, and SDN configuration (Issue #90)


### PR DESCRIPTION
Fixes version mismatch: the web app and changelog already show 0.10.4 while the README still referenced 0.10.2. This PR updates the README to align with the current release.