### PR TITLE
fix: Configuration Report shows all security details (Issue #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.5] - 2026-01-28
+
+### Fixed
+
+#### Configuration Report Security Details (Issue #7)
+
+- **Security Configuration Details Display** - Fixed a bug where the Configuration Report only showed a summary for customized security configurations instead of displaying all the individual security settings.
+  - WDAC (Windows Defender Application Control) status now displays correctly
+  - Credential Guard enforcement status now displays correctly
+  - Drift Control enforcement status now displays correctly
+  - SMB Signing enforcement status now displays correctly
+  - SMB Cluster Encryption status now displays correctly
+  - BitLocker Boot Volume status now displays correctly
+  - BitLocker Data Volumes status now displays correctly
+
+- **Property Name Alignment** - Corrected mismatched property names between the wizard state object and the report generation logic:
+  - `wdac` → `wdacEnforced`
+  - `credentialGuard` → `credentialGuardEnforced`
+  - `driftControl` → `driftControlEnforced`
+  - `smbSigning` → `smbSigningEnforced`
+  - `smbEncryption` → `smbClusterEncryption`
+  - `bitlocker` → `bitlockerBootVolume` and `bitlockerDataVolumes`
+
+---
+
 ## [0.10.4] - 2026-01-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.10.4
+## Version 0.10.5
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -36,6 +36,9 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Intelligent Validation**: Real-time input validation with helpful error messages
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
+
+### 🎉 Version 0.10.5 Bug Fix
+- **Configuration Report Security Details**: Fixed a bug where the Configuration Report only showed a summary for customized security settings. Now displays all individual security configuration details (Issue #7).
 
 ### 🎉 Version 0.10.4 Enhancement
 - **Single-Node Storage Intent Support**: Single-node clusters now support all storage intent options. Non-low-capacity single-node requires 2 RDMA ports; Low Capacity keeps RDMA optional.

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.10.4 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.10.5 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/report.js
+++ b/report.js
@@ -4208,13 +4208,13 @@
         if (s.securityConfiguration) securityRows += row('Configuration', s.securityConfiguration === 'recommended' ? 'Recommended' : 'Customized');
         if (s.securityConfiguration === 'customized' && s.securitySettings) {
             var secSettings = s.securitySettings;
-            if (secSettings.wdac !== undefined) securityRows += row('WDAC', secSettings.wdac ? 'Enabled' : 'Disabled');
-            if (secSettings.credentialGuard !== undefined) securityRows += row('Credential Guard', secSettings.credentialGuard ? 'Enabled' : 'Disabled');
-            if (secSettings.driftControl !== undefined) securityRows += row('Drift Control', secSettings.driftControl ? 'Enabled' : 'Disabled');
-            if (secSettings.smbSigning !== undefined) securityRows += row('SMB Signing', secSettings.smbSigning ? 'Enabled' : 'Disabled');
-            if (secSettings.smbEncryption !== undefined) securityRows += row('SMB Encryption', secSettings.smbEncryption ? 'Enabled' : 'Disabled');
-            if (secSettings.bitlocker !== undefined) securityRows += row('BitLocker', secSettings.bitlocker ? 'Enabled' : 'Disabled');
-            if (secSettings.sideChannelMitigation !== undefined) securityRows += row('Side Channel Mitigation', secSettings.sideChannelMitigation ? 'Enabled' : 'Disabled');
+            if (secSettings.wdacEnforced !== undefined) securityRows += row('WDAC', secSettings.wdacEnforced ? 'Enabled' : 'Disabled');
+            if (secSettings.credentialGuardEnforced !== undefined) securityRows += row('Credential Guard', secSettings.credentialGuardEnforced ? 'Enabled' : 'Disabled');
+            if (secSettings.driftControlEnforced !== undefined) securityRows += row('Drift Control', secSettings.driftControlEnforced ? 'Enabled' : 'Disabled');
+            if (secSettings.smbSigningEnforced !== undefined) securityRows += row('SMB Signing', secSettings.smbSigningEnforced ? 'Enabled' : 'Disabled');
+            if (secSettings.smbClusterEncryption !== undefined) securityRows += row('SMB Cluster Encryption', secSettings.smbClusterEncryption ? 'Enabled' : 'Disabled');
+            if (secSettings.bitlockerBootVolume !== undefined) securityRows += row('BitLocker Boot Volume', secSettings.bitlockerBootVolume ? 'Enabled' : 'Disabled');
+            if (secSettings.bitlockerDataVolumes !== undefined) securityRows += row('BitLocker Data Volumes', secSettings.bitlockerDataVolumes ? 'Enabled' : 'Disabled');
         }
 
         // Step 17: Software Defined Networking

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.10.4';
+const WIZARD_VERSION = '0.10.5';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -8327,7 +8327,21 @@ function showChangelog() {
             
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.10.4 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.10.5 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">January 28, 2026</div>
+                </div>
+                
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 Configuration Report Security Details (Issue #7)</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Security Details Display:</strong> Configuration Report now shows all security configuration details when using customized security settings.</li>
+                        <li><strong>Fixed Property Names:</strong> Corrected property name mismatches between wizard state and report rendering.</li>
+                        <li><strong>All Settings Visible:</strong> WDAC, Credential Guard, Drift Control, SMB Signing, SMB Encryption, and BitLocker settings now display correctly.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.10.4</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">January 22, 2026</div>
                 </div>
                 


### PR DESCRIPTION
## Summary

Fixes #7 - Configuration Report now shows all security configuration details instead of just a summary when using customized security settings.

## Changes

- **Fixed property name mismatches** in \eport.js\ between wizard state and report rendering:
  - \wdac\  \wdacEnforced\
  - \credentialGuard\  \credentialGuardEnforced\
  - \driftControl\  \driftControlEnforced\
  - \smbSigning\  \smbSigningEnforced\
  - \smbEncryption\  \smbClusterEncryption\
  - \itlocker\  \itlockerBootVolume\ and \itlockerDataVolumes\

- **Bumped version to 0.10.5** in:
  - \script.js\ (WIZARD_VERSION)
  - \index.html\ (header)
  - \README.md\
  - \CHANGELOG.md\
  - What's New popup

## Testing

1. Complete wizard with 'Customized' security configuration
2. Generate Configuration Report
3. Verify all security settings are displayed (WDAC, Credential Guard, Drift Control, SMB Signing, SMB Cluster Encryption, BitLocker Boot/Data Volumes)