### PR TITLE
v0.10.9: Auto IP storage display correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.9] - 2026-01-28
+
+### Fixed
+
+#### Auto IP Storage Display Correction
+
+- **Subnet-Only Display for Auto IP** - When Storage Auto IP is enabled, the Configuration Report now correctly shows only the subnet (10.71.0.0/16) instead of calculated IP addresses. This reflects the reality that Network ATC assigns IPs automatically and the actual addresses are not known until deployment.
+
+- **Custom Subnets Unchanged** - When Storage Auto IP is disabled, the report continues to display calculated storage adapter IP addresses for each node, as these are user-defined values that will be used in the ARM template.
+
+---
+
 ## [0.10.8] - 2026-01-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.10.8
+## Version 0.10.9
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -36,6 +36,9 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Intelligent Validation**: Real-time input validation with helpful error messages
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
+
+### 🎉 Version 0.10.9 Bug Fix
+- **Auto IP Storage Display Correction**: When Storage Auto IP is enabled, the report now correctly shows only the subnet (10.71.0.0/16) since IPs are assigned automatically by Network ATC. Custom subnets continue to show calculated IPs.
 
 ### 🎉 Version 0.10.8 Bug Fix
 - **Storage Adapter IPs for Auto IP Enabled**: Configuration Report now shows default Network ATC storage adapter IPs (10.71.x.x) when Storage Auto IP is enabled, not just when disabled.

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.10.8 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.10.9 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/report.js
+++ b/report.js
@@ -4171,26 +4171,8 @@
         // Display storage subnet information based on Auto IP setting
         if (s.storageAutoIp === 'enabled') {
             // Show default Network ATC subnets when Auto IP is enabled
-            hostNetworkingRows += row('Storage Subnets', 'Default Network ATC (10.71.0.0/16)');
-            // Show default storage adapter IPs for each node when Auto IP is enabled
-            var nodeCount = parseInt(s.nodes, 10) || 0;
-            if (nodeCount > 0) {
-                var autoIpDetails = [];
-                // Network ATC assigns IPs from 10.71.x.0/24 subnets - SMB1 uses .1 subnet, SMB2 uses .2 subnet
-                for (var smbIdx = 1; smbIdx <= 2; smbIdx++) {
-                    var nodeAutoIps = [];
-                    for (var nIdx = 0; nIdx < nodeCount; nIdx++) {
-                        var nodeName = (Array.isArray(s.nodeSettings) && s.nodeSettings[nIdx] && s.nodeSettings[nIdx].name) 
-                            ? s.nodeSettings[nIdx].name : ('Node' + (nIdx + 1));
-                        // Network ATC uses 10.71.{smbIdx}.{nIdx+1} pattern
-                        nodeAutoIps.push(nodeName + ': 10.71.' + smbIdx + '.' + (nIdx + 1));
-                    }
-                    autoIpDetails.push('SMB' + smbIdx + ' (10.71.' + smbIdx + '.0/24) - ' + nodeAutoIps.join(', '));
-                }
-                if (autoIpDetails.length > 0) {
-                    hostNetworkingRows += row('Storage Adapter IPs', autoIpDetails.join('; '), true);
-                }
-            }
+            // Note: We don't show specific IPs because Network ATC assigns them automatically
+            hostNetworkingRows += row('Storage Subnets', 'Default Network ATC (10.71.0.0/16) - IPs assigned automatically');
         } else if (s.storageAutoIp === 'disabled' && Array.isArray(s.customStorageSubnets) && s.customStorageSubnets.length > 0) {
             // Show custom storage subnets when Auto IP is disabled
             var validSubnets = s.customStorageSubnets.filter(function(subnet) { return subnet && String(subnet).trim(); });

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.10.8';
+const WIZARD_VERSION = '0.10.9';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -8327,7 +8327,20 @@ function showChangelog() {
             
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.10.8 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.10.9 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">January 28, 2026</div>
+                </div>
+                
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 Auto IP Storage Display Correction</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Auto IP Subnet Only:</strong> When Storage Auto IP is enabled, report now shows only the subnet (10.71.0.0/16) since IPs are assigned automatically by Network ATC.</li>
+                        <li><strong>Custom Subnets Unchanged:</strong> Storage adapter IPs continue to display when Auto IP is disabled (user-defined subnets).</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.10.8</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">January 28, 2026</div>
                 </div>
                 


### PR DESCRIPTION
When Storage Auto IP is enabled, the Configuration Report now correctly shows only the subnet (10.71.0.0/16) instead of calculated IP addresses. Network ATC assigns IPs automatically so the actual addresses are not known until deployment.