### PR TITLE
v0.10.11: Switchless storage IPs by SMB adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.10.11] - 2026-01-28
+
+### Fixed
+
+#### Switchless Storage IPs by Adapter
+
+- **ARM Template Alignment** - Switchless storage adapter IPs now display grouped by SMB adapter name (SMB1, SMB2, SMB3, etc.) matching the exact structure used in ARM template generation.
+
+- **Node-to-IP Mapping** - Each adapter shows which node gets which IP address, consistent with the generated ARM parameters file.
+
+- **Full Node Count Support** - Proper subnet-to-adapter mapping for 2-node, 3-node, and 4-node switchless configurations with correct host octet assignment (.2 for lower node, .3 for higher node).
+
+---
+
 ## [0.10.10] - 2026-01-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.10.10
+## Version 0.10.11
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -36,6 +36,9 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Intelligent Validation**: Real-time input validation with helpful error messages
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
+
+### 🎉 Version 0.10.11 Bug Fix
+- **Switchless Storage IPs by Adapter**: Switchless storage adapter IPs now display grouped by SMB adapter name (SMB1, SMB2, etc.) matching the ARM template structure, showing which node gets which IP.
 
 ### 🎉 Version 0.10.10 Bug Fix
 - **Switchless Storage Adapter IPs**: Configuration Report now displays storage adapter IPs for switchless storage when Auto IP is disabled. Each subnet shows its two assigned IPs per node pair.

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.10.10 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.10.11 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.10.10';
+const WIZARD_VERSION = '0.10.11';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -8327,7 +8327,21 @@ function showChangelog() {
             
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.10.10 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.10.11 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">January 28, 2026</div>
+                </div>
+                
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 Switchless Storage IPs by Adapter</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>ARM Template Alignment:</strong> Switchless storage adapter IPs now display grouped by SMB adapter (SMB1, SMB2, etc.) matching the ARM template structure.</li>
+                        <li><strong>Node-to-IP Mapping:</strong> Each adapter shows which node gets which IP, consistent with the generated ARM parameters.</li>
+                        <li><strong>2/3/4-Node Support:</strong> Proper subnet-to-adapter mapping for all switchless node counts.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.10.10</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">January 28, 2026</div>
                 </div>
                 


### PR DESCRIPTION
Switchless storage adapter IPs now display grouped by SMB adapter name (SMB1, SMB2, etc.) matching the ARM template structure. Each adapter shows which node gets which IP, with proper subnet-to-adapter mapping for 2-node, 3-node, and 4-node configurations.