### PR TITLE
docs: Add supported private endpoint services to comparison table

### DIFF
--- a/docs/outbound-connectivity/index.html
+++ b/docs/outbound-connectivity/index.html
@@ -157,6 +157,10 @@
                         <td>✅ Supported</td>
                     </tr>
                     <tr>
+                        <td><strong>Supported PE Services</strong></td>
+                        <td colspan="2" style="text-align: center;">Key Vault, Storage (Blob), Azure Container Registry, Azure Site Recovery, Recovery Services Vault (Backup), SQL Managed Instance, Microsoft Defender for Cloud</td>
+                    </tr>
+                    <tr>
                         <td><strong>Arc Private Link</strong></td>
                         <td>❌ Not supported</td>
                         <td>❌ Not supported</td>


### PR DESCRIPTION
Adds a new row to the Detailed Comparison table showing all supported Private Endpoint services:

- Key Vault
- Storage (Blob)
- Azure Container Registry
- Azure Site Recovery
- Recovery Services Vault (Backup)
- SQL Managed Instance
- Microsoft Defender for Cloud