### PR TITLE
docs: Add individual PE service rows to comparison table

### DIFF
--- a/docs/outbound-connectivity/index.html
+++ b/docs/outbound-connectivity/index.html
@@ -157,8 +157,39 @@
                         <td>✅ Supported</td>
                     </tr>
                     <tr>
-                        <td><strong>Supported PE Services</strong></td>
-                        <td colspan="2" style="text-align: center;">Key Vault, Storage (Blob), Azure Container Registry, Azure Site Recovery, Recovery Services Vault (Backup), SQL Managed Instance, Microsoft Defender for Cloud</td>
+                        <td style="padding-left: 2rem;">🔐 Key Vault</td>
+                        <td>✅</td>
+                        <td>✅</td>
+                    </tr>
+                    <tr>
+                        <td style="padding-left: 2rem;">💾 Storage (Blob)</td>
+                        <td>✅</td>
+                        <td>✅</td>
+                    </tr>
+                    <tr>
+                        <td style="padding-left: 2rem;">📦 Azure Container Registry</td>
+                        <td>✅</td>
+                        <td>✅</td>
+                    </tr>
+                    <tr>
+                        <td style="padding-left: 2rem;">🔄 Azure Site Recovery</td>
+                        <td>✅</td>
+                        <td>✅</td>
+                    </tr>
+                    <tr>
+                        <td style="padding-left: 2rem;">🗄️ Recovery Services Vault (Backup)</td>
+                        <td>✅</td>
+                        <td>✅</td>
+                    </tr>
+                    <tr>
+                        <td style="padding-left: 2rem;">🗃️ SQL Managed Instance</td>
+                        <td>✅</td>
+                        <td>✅</td>
+                    </tr>
+                    <tr>
+                        <td style="padding-left: 2rem;">🛡️ Microsoft Defender for Cloud</td>
+                        <td>✅</td>
+                        <td>✅</td>
                     </tr>
                     <tr>
                         <td><strong>Arc Private Link</strong></td>


### PR DESCRIPTION
Replaces the single 'Supported PE Services' row with individual rows for each Private Endpoint service, each with checkmarks for both Public Path and Private Path:

-  Key Vault
-  Storage (Blob)
-  Azure Container Registry
-  Azure Site Recovery
-  Recovery Services Vault (Backup)
-  SQL Managed Instance
-  Microsoft Defender for Cloud