### PR TITLE
docs: Move Arc Private Link to top of PE list

### DIFF
--- a/docs/outbound-connectivity/index.html
+++ b/docs/outbound-connectivity/index.html
@@ -157,6 +157,11 @@
                         <td>✅ Supported</td>
                     </tr>
                     <tr>
+                        <td style="padding-left: 2rem;">� Arc Private Link</td>
+                        <td>❌</td>
+                        <td>❌</td>
+                    </tr>
+                    <tr>
                         <td style="padding-left: 2rem;">🔐 Key Vault</td>
                         <td>✅</td>
                         <td>✅</td>
@@ -190,11 +195,6 @@
                         <td style="padding-left: 2rem;">🛡️ Microsoft Defender for Cloud</td>
                         <td>✅</td>
                         <td>✅</td>
-                    </tr>
-                    <tr>
-                        <td><strong>Arc Private Link</strong></td>
-                        <td>❌ Not supported</td>
-                        <td>❌ Not supported</td>
                     </tr>
                     <tr>
                         <td><strong>TLS Inspection</strong></td>


### PR DESCRIPTION
Moves Arc Private Link into the Private Endpoints list as the first item (with  since it's not supported).