### PR TITLE
feat: Add Tab Navigation System for Designer, Knowledge, and Sizer (Issue #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.0] - 2026-02-04
+
+### Added
+
+#### Tab Navigation System (Issue #24)
+
+- **Top Navigation Bar** - New fixed navigation bar at the top of the page with ODIN branding and tab buttons for Designer, Knowledge, and Sizer sections.
+
+- **ODIN Designer Tab** - The existing wizard functionality is now accessible via the Designer tab, which is the default active view.
+
+- **ODIN Knowledge Tab** - Quick access to the documentation section, linking to the Outbound Connectivity Guide and future knowledge base articles.
+
+- **ODIN Sizer Tab** - Placeholder for the upcoming cluster sizing tool with "Coming Soon" badge. Will help calculate Azure Local cluster sizing based on workload requirements.
+
+- **Consistent Navigation Across Pages** - Both the main index.html and docs pages now share the same navigation pattern, making ODIN feel like a cohesive single-site application.
+
+- **Session Persistence** - Active tab state is saved to session storage, so users return to their last viewed tab when navigating back.
+
+### Changed
+
+#### Documentation Page Updates
+
+- **Docs Navigation Consistency** - The `/docs/outbound-connectivity/` page now includes the same top navigation bar as the main site.
+
+- **Sidebar Repositioned** - Documentation sidebar now starts below the fixed top nav for proper layout.
+
+- **Mobile Responsive** - Tab navigation adapts gracefully to smaller screens with condensed styling.
+
+---
+
 ## [0.10.12] - 2026-02-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.10.12
+## Version 0.11.0
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,15 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.10.12 New Features
+### 🎉 Version 0.11.0 New Features
+- **Tab Navigation System**: New top navigation bar with tabs for Designer, Knowledge, and Sizer sections
+- **ODIN Designer**: The existing wizard is now accessible via the Designer tab (default view)
+- **ODIN Knowledge**: Quick access to documentation including the Outbound Connectivity Guide
+- **ODIN Sizer**: Placeholder for upcoming cluster sizing tool (Coming Soon)
+- **Consistent Navigation**: Both main site and docs pages share the same navigation pattern
+- **Session Persistence**: Active tab state persists during browser session
+
+### 🎉 Version 0.10.12 Previous Features
 - **Outbound Connectivity Guide**: Integrated comprehensive documentation with architecture diagrams for Public Path vs Private Path (ExpressRoute) scenarios
 - **Private Endpoints Selection**: New wizard step for selecting Azure services that use Private Link (Key Vault, Storage, ACR, ASR, Backup, SQL MI, Defender)
 - **Dynamic Connectivity Diagrams**: Configuration Report displays the appropriate architecture diagram based on your outbound, Arc Gateway, and proxy selections

--- a/docs/outbound-connectivity/index.html
+++ b/docs/outbound-connectivity/index.html
@@ -8,17 +8,45 @@
     <link href="https://fonts.googleapis.com/css2?family=Segoe+UI:wght@300;400;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
+    <!-- Tab Navigation (consistent with main site) -->
+    <nav class="odin-tab-nav">
+        <div class="odin-tab-container">
+            <a href="../../index.html" class="odin-tab-logo">
+                <img src="images/odin-logo.png" alt="Odin">
+                <span>ODIN</span>
+            </a>
+            <a href="../../index.html" class="odin-tab-btn" data-tab="designer">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <rect x="3" y="3" width="18" height="18" rx="2"/>
+                    <path d="M3 9h18M9 21V9"/>
+                </svg>
+                Designer
+            </a>
+            <a href="#" class="odin-tab-btn active" data-tab="knowledge">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
+                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+                </svg>
+                Knowledge
+            </a>
+            <a href="../../index.html" class="odin-tab-btn" data-tab="sizer" onclick="sessionStorage.setItem('odinActiveTab', 'sizer');">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M3 3v18h18"/>
+                    <path d="M18 17V9"/>
+                    <path d="M13 17V5"/>
+                    <path d="M8 17v-3"/>
+                </svg>
+                Sizer
+                <span class="odin-tab-badge">Coming Soon</span>
+            </a>
+        </div>
+    </nav>
+
     <nav class="sidebar">
         <div class="sidebar-header">
-            <a href="../../index.html" style="text-decoration: none;">
-                <img src="images/odin-logo.png" alt="Odin for Azure Local" class="logo">
-            </a>
             <h2>Azure Local</h2>
             <p>Outbound Connectivity Guide</p>
             <span class="version-badge">v1.0</span>
-            <a href="../../index.html" style="display: block; margin-top: 12px; padding: 8px 12px; background: rgba(59, 130, 246, 0.1); border: 1px solid rgba(59, 130, 246, 0.3); color: #60a5fa; border-radius: 6px; text-decoration: none; font-size: 0.85rem; text-align: center;">
-                ← Back to Odin Wizard
-            </a>
         </div>
         <ul class="nav-links">
             <li><a href="#overview" class="active">Overview</a></li>

--- a/docs/outbound-connectivity/styles.css
+++ b/docs/outbound-connectivity/styles.css
@@ -20,6 +20,105 @@
     --subtle-bg-hover: rgba(255, 255, 255, 0.06);
 }
 
+/* ===========================================
+   Top Tab Navigation (consistent with main site)
+   =========================================== */
+.odin-tab-nav {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    background: linear-gradient(180deg, rgba(17, 17, 17, 0.98) 0%, rgba(17, 17, 17, 0.95) 100%);
+    backdrop-filter: blur(20px);
+    border-bottom: 1px solid var(--glass-border);
+    padding: 0 24px;
+}
+
+.odin-tab-container {
+    max-width: 1400px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 56px;
+}
+
+.odin-tab-logo {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding-right: 24px;
+    border-right: 1px solid var(--glass-border);
+    margin-right: 16px;
+    text-decoration: none;
+}
+
+.odin-tab-logo img {
+    width: 32px;
+    height: 32px;
+}
+
+.odin-tab-logo span {
+    font-weight: 600;
+    font-size: 16px;
+    color: var(--text-primary);
+}
+
+.odin-tab-btn {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 20px;
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+    border-radius: 8px;
+    transition: all 0.2s ease;
+    position: relative;
+    text-decoration: none;
+}
+
+.odin-tab-btn:hover {
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-primary);
+}
+
+.odin-tab-btn.active {
+    background: rgba(0, 120, 212, 0.15);
+    color: var(--accent-blue);
+}
+
+.odin-tab-btn.active::after {
+    content: '';
+    position: absolute;
+    bottom: -8px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 40px;
+    height: 3px;
+    background: var(--accent-blue);
+    border-radius: 3px 3px 0 0;
+}
+
+.odin-tab-btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.odin-tab-badge {
+    padding: 2px 8px;
+    background: rgba(139, 92, 246, 0.2);
+    color: var(--accent-purple);
+    font-size: 10px;
+    font-weight: 600;
+    border-radius: 10px;
+    text-transform: uppercase;
+}
+
 /* Reset and Base Styles */
 * {
     margin: 0;
@@ -38,6 +137,7 @@ body {
     line-height: 1.6;
     min-height: 100vh;
     display: flex;
+    padding-top: 56px;
 }
 
 /* Background Gradient Effect */
@@ -60,10 +160,10 @@ body::before {
     width: 300px;
     background: var(--card-bg-transparent);
     backdrop-filter: blur(20px);
-    height: 100vh;
+    height: calc(100vh - 56px);
     position: fixed;
     left: 0;
-    top: 0;
+    top: 56px;
     overflow-y: auto;
     padding: 0;
     z-index: 100;
@@ -1122,10 +1222,48 @@ p {
 }
 
 @media (max-width: 768px) {
+    .odin-tab-nav {
+        padding: 0 12px;
+    }
+    
+    .odin-tab-container {
+        height: 48px;
+        gap: 4px;
+    }
+    
+    .odin-tab-logo {
+        padding-right: 12px;
+        margin-right: 8px;
+    }
+    
+    .odin-tab-logo span {
+        display: none;
+    }
+    
+    .odin-tab-btn {
+        padding: 8px 12px;
+        font-size: 12px;
+    }
+    
+    .odin-tab-btn svg {
+        width: 16px;
+        height: 16px;
+    }
+    
+    .odin-tab-badge {
+        display: none;
+    }
+    
+    body {
+        flex-direction: column;
+        padding-top: 48px;
+    }
+    
     .sidebar {
         width: 100%;
         height: auto;
         position: relative;
+        top: 0;
         border-right: none;
         border-bottom: 1px solid var(--glass-border);
     }
@@ -1134,10 +1272,6 @@ p {
         margin-left: 0;
         max-width: 100%;
         padding: 20px;
-    }
-    
-    body {
-        flex-direction: column;
     }
     
     .section {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <link rel="stylesheet" href="style.css">
 </head>
 
-<body>
+<body class="has-tab-nav">
     <style>
         .reset-button {
             width: 100%;
@@ -76,9 +76,198 @@
             height: 18px;
             margin-top: 2px;
         }
+
+        /* Tab Navigation System */
+        .odin-tab-nav {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1000;
+            background: linear-gradient(180deg, rgba(17, 17, 17, 0.98) 0%, rgba(17, 17, 17, 0.95) 100%);
+            backdrop-filter: blur(20px);
+            border-bottom: 1px solid var(--glass-border);
+            padding: 0 24px;
+        }
+
+        .odin-tab-container {
+            max-width: 1400px;
+            margin: 0 auto;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            height: 56px;
+        }
+
+        .odin-tab-logo {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding-right: 24px;
+            border-right: 1px solid var(--glass-border);
+            margin-right: 16px;
+        }
+
+        .odin-tab-logo img {
+            width: 32px;
+            height: 32px;
+        }
+
+        .odin-tab-logo span {
+            font-weight: 600;
+            font-size: 16px;
+            color: var(--text-primary);
+        }
+
+        .odin-tab-btn {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 10px 20px;
+            background: transparent;
+            border: none;
+            color: var(--text-secondary);
+            font-size: 14px;
+            font-weight: 500;
+            cursor: pointer;
+            border-radius: 8px;
+            transition: all 0.2s ease;
+            position: relative;
+            text-decoration: none;
+        }
+
+        .odin-tab-btn:hover {
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text-primary);
+        }
+
+        .odin-tab-btn.active {
+            background: rgba(0, 120, 212, 0.15);
+            color: var(--accent-blue);
+        }
+
+        .odin-tab-btn.active::after {
+            content: '';
+            position: absolute;
+            bottom: -8px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 40px;
+            height: 3px;
+            background: var(--accent-blue);
+            border-radius: 3px 3px 0 0;
+        }
+
+        .odin-tab-btn svg {
+            width: 18px;
+            height: 18px;
+        }
+
+        .odin-tab-badge {
+            padding: 2px 8px;
+            background: rgba(139, 92, 246, 0.2);
+            color: var(--accent-purple);
+            font-size: 10px;
+            font-weight: 600;
+            border-radius: 10px;
+            text-transform: uppercase;
+        }
+
+        /* Add top padding to body to account for fixed nav */
+        body.has-tab-nav {
+            padding-top: 56px;
+        }
+
+        /* Tab content sections */
+        .odin-tab-content {
+            display: none;
+        }
+
+        .odin-tab-content.active {
+            display: block;
+        }
+
+        /* Coming Soon placeholder */
+        .odin-coming-soon {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            min-height: 60vh;
+            text-align: center;
+            padding: 48px 24px;
+        }
+
+        .odin-coming-soon-icon {
+            width: 80px;
+            height: 80px;
+            background: rgba(139, 92, 246, 0.1);
+            border: 2px solid rgba(139, 92, 246, 0.3);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-bottom: 24px;
+        }
+
+        .odin-coming-soon-icon svg {
+            width: 40px;
+            height: 40px;
+            color: var(--accent-purple);
+        }
+
+        .odin-coming-soon h2 {
+            font-size: 28px;
+            font-weight: 600;
+            margin-bottom: 12px;
+            color: var(--text-primary);
+        }
+
+        .odin-coming-soon p {
+            color: var(--text-secondary);
+            font-size: 16px;
+            max-width: 500px;
+            line-height: 1.6;
+        }
     </style>
     <div class="background-globes"></div>
 
+    <!-- Tab Navigation -->
+    <nav class="odin-tab-nav">
+        <div class="odin-tab-container">
+            <div class="odin-tab-logo">
+                <img src="odin-logo.png" alt="Odin">
+                <span>ODIN</span>
+            </div>
+            <button class="odin-tab-btn active" data-tab="designer" onclick="switchOdinTab('designer')">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <rect x="3" y="3" width="18" height="18" rx="2"/>
+                    <path d="M3 9h18M9 21V9"/>
+                </svg>
+                Designer
+            </button>
+            <a href="docs/outbound-connectivity/index.html" class="odin-tab-btn" data-tab="knowledge">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
+                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+                </svg>
+                Knowledge
+            </a>
+            <button class="odin-tab-btn" data-tab="sizer" onclick="switchOdinTab('sizer')">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M3 3v18h18"/>
+                    <path d="M18 17V9"/>
+                    <path d="M13 17V5"/>
+                    <path d="M8 17v-3"/>
+                </svg>
+                Sizer
+                <span class="odin-tab-badge">Coming Soon</span>
+            </button>
+        </div>
+    </nav>
+
+    <!-- Designer Tab Content -->
+    <div id="tab-designer" class="odin-tab-content active">
     <main class="container">
         <!-- Breadcrumb Navigation -->
         <nav id="breadcrumb-nav" class="breadcrumb-nav hidden" aria-label="Wizard steps navigation">
@@ -145,7 +334,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.10.12 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.11.0 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>
@@ -1956,6 +2145,27 @@
         </div> <!-- End layout-flex -->
 
     </main>
+    </div> <!-- End Designer Tab Content -->
+
+    <!-- Sizer Tab Content -->
+    <div id="tab-sizer" class="odin-tab-content">
+        <main class="container">
+            <div class="odin-coming-soon">
+                <div class="odin-coming-soon-icon">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M3 3v18h18"/>
+                        <path d="M18 17V9"/>
+                        <path d="M13 17V5"/>
+                        <path d="M8 17v-3"/>
+                    </svg>
+                </div>
+                <h2>ODIN Sizer</h2>
+                <p>The ODIN Sizer tool is currently under development. This feature will help you calculate and optimize your Azure Local cluster sizing based on workload requirements.</p>
+                <p style="margin-top: 16px; color: var(--accent-purple); font-weight: 500;">Stay tuned for updates!</p>
+            </div>
+        </main>
+    </div> <!-- End Sizer Tab Content -->
+
     <script src="script.js"></script>
 </body>
 

--- a/script.js
+++ b/script.js
@@ -1,7 +1,51 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.10.12';
+const WIZARD_VERSION = '0.11.0';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
+
+// ============================================================================
+// TAB NAVIGATION MODULE
+// ============================================================================
+// Handles switching between different ODIN tabs (Designer, Knowledge, Sizer)
+// ============================================================================
+
+/**
+ * Switch between ODIN tabs
+ * @param {string} tabId - The tab identifier ('designer', 'knowledge', 'sizer')
+ */
+function switchOdinTab(tabId) {
+    // Update tab buttons
+    const tabButtons = document.querySelectorAll('.odin-tab-btn');
+    tabButtons.forEach(btn => {
+        btn.classList.remove('active');
+        if (btn.dataset.tab === tabId) {
+            btn.classList.add('active');
+        }
+    });
+
+    // Update tab content
+    const tabContents = document.querySelectorAll('.odin-tab-content');
+    tabContents.forEach(content => {
+        content.classList.remove('active');
+    });
+
+    const targetContent = document.getElementById(`tab-${tabId}`);
+    if (targetContent) {
+        targetContent.classList.add('active');
+    }
+
+    // Save current tab to session storage for persistence during page session
+    sessionStorage.setItem('odinActiveTab', tabId);
+}
+
+// Restore active tab on page load (if navigating back)
+document.addEventListener('DOMContentLoaded', function() {
+    const savedTab = sessionStorage.getItem('odinActiveTab');
+    if (savedTab && savedTab !== 'knowledge') {
+        // Knowledge tab navigates away, so don't try to switch to it
+        switchOdinTab(savedTab);
+    }
+});
 
 // ============================================================================
 // FIREBASE ANALYTICS MODULE
@@ -8586,7 +8630,37 @@ function showChangelog() {
             
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.10.11 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.11.0 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 4, 2026</div>
+                </div>
+                
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🧭 Tab Navigation System</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Top Navigation Bar:</strong> New fixed navigation with ODIN branding and tabs for Designer, Knowledge, and Sizer sections.</li>
+                        <li><strong>ODIN Designer:</strong> The existing wizard is now accessible via the Designer tab (default view).</li>
+                        <li><strong>ODIN Knowledge:</strong> Quick access to documentation including the Outbound Connectivity Guide.</li>
+                        <li><strong>ODIN Sizer:</strong> Placeholder for upcoming cluster sizing tool (Coming Soon).</li>
+                        <li><strong>Consistent Navigation:</strong> Main site and docs pages share the same navigation pattern.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.10.12</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 3, 2026</div>
+                </div>
+                
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">📡 Outbound Connectivity Guide</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Architecture Documentation:</strong> Comprehensive guide for Public Path vs Private Path (ExpressRoute) scenarios.</li>
+                        <li><strong>Private Endpoints Selection:</strong> New wizard step for selecting Azure services that use Private Link.</li>
+                        <li><strong>Dynamic Connectivity Diagrams:</strong> Report displays appropriate architecture diagram based on your selections.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.10.11</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">January 28, 2026</div>
                 </div>
                 


### PR DESCRIPTION
## Summary

This PR implements the tab navigation system requested in Issue #24, introducing a cohesive navigation experience across ODIN with three main sections: Designer, Knowledge, and Sizer.

## Changes

###  Top Navigation Bar
- Fixed position navigation bar at the top of the page with ODIN branding
- Three tab buttons: **Designer**, **Knowledge**, and **Sizer**
- Consistent styling matching the existing dark theme aesthetic
- Responsive design that adapts to mobile screens

###  ODIN Designer Tab (Default)
- The existing wizard functionality is now accessible via the Designer tab
- All existing functionality preserved - no breaking changes
- Automatically selected when users visit the site

###  ODIN Knowledge Tab
- Links directly to the \/docs/outbound-connectivity/\ documentation
- Documentation page updated with matching navigation bar
- 'Knowledge' tab appears active when viewing docs
- Easy navigation back to Designer or Sizer from docs pages

###  ODIN Sizer Tab (Coming Soon)
- Placeholder page with styled 'Coming Soon' message
- Purple 'Coming Soon' badge on the tab button
- Ready for future cluster sizing tool implementation

## Files Modified

| File | Changes |
|------|---------|
| \index.html\ | Added tab navigation HTML, CSS styles, content wrappers for Designer and Sizer tabs |
| \script.js\ | Added \switchOdinTab()\ function, session persistence, version bump to 0.11.0 |
| \docs/outbound-connectivity/index.html\ | Added matching tab navigation for consistent UX |
| \docs/outbound-connectivity/styles.css\ | Added tab navigation styles and layout adjustments |
| \README.md\ | Updated version to 0.11.0 and documented new features |
| \CHANGELOG.md\ | Added comprehensive v0.11.0 changelog entry |

## Technical Details

### Session Persistence
- Active tab state saved to \sessionStorage\
- Users return to their last viewed tab when navigating back

### Mobile Responsive
- Tab navigation condenses on smaller screens
- ODIN text hidden on mobile (logo only)
- 'Coming Soon' badge hidden on mobile to save space

### No Breaking Changes
- All existing wizard functionality remains intact
- Designer tab is the default view
- Existing URLs continue to work

## Testing

- [x] Designer tab displays existing wizard correctly
- [x] Knowledge tab navigates to docs
- [x] Sizer tab shows Coming Soon placeholder
- [x] Tab switching works correctly
- [x] Session persistence maintains tab state
- [x] Mobile responsive design works
- [x] Docs page has consistent navigation

Closes #24