### PR TITLE
Fix duplicate Nodes entry in incomplete sections list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed Section Hidden Behind Sticky Headers** - Added `scroll-margin-top: 140px` to `.step` elements to prevent wizard sections from being hidden behind the fixed navigation bar (56px) and sticky breadcrumb/progress bar (~80px) when navigating via the incomplete sections list.
 
+- **Fixed Duplicate "Nodes" Entry** - Fixed an issue where "Nodes" appeared twice in the incomplete sections list when the node count wasn't selected. The duplicate check was removed from `getReportReadiness()` since it's already handled by `getNodeSettingsReadiness()`.
+
 ---
 
 ## [0.12.5] - 2026-02-04

--- a/script.js
+++ b/script.js
@@ -720,7 +720,7 @@ function getReportReadiness() {
     if (!state.region) missing.push('Azure Cloud');
     if (!state.localInstanceRegion) missing.push('Azure Local Instance Region');
     if (!state.scale) missing.push('Scale');
-    if (!state.nodes) missing.push('Nodes');
+    // Note: 'Nodes' check is handled by getNodeSettingsReadiness() to avoid duplication
     if (!state.witnessType) missing.push('Cloud Witness Type');
 
     if (state.scale === 'rack_aware') {


### PR DESCRIPTION
## Issue
'Nodes' was appearing twice in the 'Complete These Sections' list when the node count wasn't selected.

## Root Cause
The check for \!state.nodes\ was duplicated:
1. In \getReportReadiness()\ at line 723
2. In \getNodeSettingsReadiness()\ at line 1320

Both functions were adding 'Nodes' to the missing array.

## Fix
Removed the redundant check from \getReportReadiness()\ since \getNodeSettingsReadiness()\ already handles it and is called later in the same function.