### PR TITLE
Fix Start Over button not fully resetting wizard state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fixed Duplicate "Nodes" Entry** - Fixed an issue where "Nodes" appeared twice in the incomplete sections list when the node count wasn't selected. The duplicate check was removed from `getReportReadiness()` since it's already handled by `getNodeSettingsReadiness()`.
 
+- **Fixed "Start Over" Reset Issues** - Comprehensively fixed the `resetAll()` function to properly reset the entire wizard:
+  - Added missing state property resets (witnessType, privateEndpoints, portConfig, nodeSettings, securityConfiguration, securitySettings, sdnEnabled, rackAware properties, torSwitchCount, storagePoolConfiguration, adapterMapping, etc.)
+  - Added scroll to top of page after reset so wizard starts at Step 1
+  - Added removal of `.selected` class from all option cards
+  - Added clearing of localStorage saved state
+  - Added reset of Private Endpoints and SDN Features checkboxes
+  - Added toast notification to confirm reset
+
 ---
 
 ## [0.12.5] - 2026-02-04

--- a/script.js
+++ b/script.js
@@ -7174,14 +7174,25 @@ function applyInfraVlanVisibility() {
 }
 
 function resetAll() {
+    // Reset all state properties to initial values
     state.scenario = null;
     state.region = null;
     state.localInstanceRegion = null;
     state.scale = null;
     state.nodes = null;
+    state.witnessType = null;
     state.ports = null;
     state.storage = null;
+    state.torSwitchCount = null;
+    state.switchlessLinkMode = null;
+    state.storagePoolConfiguration = null;
+    state.rackAwareZones = null;
+    state.rackAwareZonesConfirmed = false;
+    state.rackAwareZoneSwapSelection = null;
+    state.rackAwareTorsPerRoom = null;
+    state.rackAwareTorArchitecture = null;
     state.intent = null;
+    state.customIntentConfirmed = false;
     state.outbound = null;
     state.arc = null;
     state.proxy = null;
@@ -7191,9 +7202,12 @@ function resetAll() {
     state.infraCidrAuto = true;
     state.infraGateway = null;
     state.infraGatewayManual = false;
+    state.nodeSettings = [];
     state.infraVlan = null;
     state.infraVlanId = null;
     state.storageAutoIp = null;
+    state.customStorageSubnets = [];
+    state.customStorageSubnetsConfirmed = false;
     state.activeDirectory = null;
     state.adDomain = null;
     state.adOuPath = null;
@@ -7201,10 +7215,31 @@ function resetAll() {
     state.dnsServers = [];
     state.localDnsZone = null;
     state.dnsServiceExisting = null;
+    state.sdnEnabled = null;
     state.sdnFeatures = [];
     state.sdnManagement = null;
+    state.intentOverrides = {};
     state.customIntents = {};
+    state.adapterMapping = {};
+    state.adapterMappingConfirmed = false;
+    state.adapterMappingSelection = null;
+    state.overridesConfirmed = false;
+    state.securityConfiguration = null;
+    state.securitySettings = {
+        driftControlEnforced: true,
+        bitlockerBootVolume: true,
+        bitlockerDataVolumes: true,
+        wdacEnforced: true,
+        credentialGuardEnforced: true,
+        smbSigningEnforced: true,
+        smbClusterEncryption: true
+    };
+    state.rdmaGuardMessage = null;
+    state.privateEndpoints = null;
+    state.privateEndpointsList = [];
+    state.portConfig = [];
 
+    // Clear input fields
     const cidrInput = document.getElementById('infra-cidr');
     const startInput = document.getElementById('infra-ip-start');
     const endInput = document.getElementById('infra-ip-end');
@@ -7246,8 +7281,14 @@ function resetAll() {
 
     const sdnSection = document.getElementById('sdn-management-section');
     if (sdnSection) sdnSection.classList.add('hidden');
+    
+    const sdnFeaturesSection = document.getElementById('sdn-features-section');
+    if (sdnFeaturesSection) sdnFeaturesSection.classList.add('hidden');
 
     document.querySelectorAll('.sdn-feature-card input[type="checkbox"]').forEach(cb => cb.checked = false);
+
+    // Reset PE checkboxes
+    document.querySelectorAll('#pe-options-grid input[type="checkbox"]').forEach(cb => cb.checked = false);
 
     renderDnsServers();
 
@@ -7260,7 +7301,21 @@ function resetAll() {
         }
     });
 
+    // Remove selected state from all option cards
+    document.querySelectorAll('.option-card.selected').forEach(card => {
+        card.classList.remove('selected');
+    });
+
+    // Clear localStorage
+    clearSavedState();
+
+    // Update UI to reflect clean state
     updateUI();
+
+    // Scroll to top of page (to step 1)
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+
+    showToast('Started fresh - all previous data cleared', 'info');
 }
 
 function addDnsServer() {


### PR DESCRIPTION
## Issue
When clicking 'Start Over', the wizard was not properly resetting:
1. Many options remained selected instead of being greyed out
2. The page was not scrolling to the top to start the wizard again
3. Some state properties were not being reset

## Root Cause
The \esetAll()\ function was missing many state property resets compared to the full state object definition, and was missing scroll-to-top and UI cleanup logic.

## Fix
Comprehensively updated \esetAll()\ to:
- Reset ALL state properties to their initial values (added ~20 missing properties including witnessType, privateEndpoints, portConfig, nodeSettings, securityConfiguration, sdnEnabled, rackAware properties, etc.)
- Scroll to top of page after reset
- Remove \.selected\ class from all option cards
- Clear localStorage saved state
- Reset Private Endpoints and SDN Features checkboxes
- Show toast notification confirming the reset