### PR TITLE
Add custom network adapter port naming feature (v0.13.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.0] - 2026-02-05
+
+### Added
+
+#### Custom Network Adapter Port Naming
+
+- **Editable Port Names** - Users can now customize network adapter port names in the Port Configuration section (Step 07) to match their existing Windows naming conventions. Simply click on any port name to rename it (e.g., "Slot3-Port1", "NIC-MGMT-01", etc.).
+
+- **Propagated Throughout Wizard** - Custom port names automatically appear in:
+  - Adapter Mapping Configuration (Step 08) - adapter chips display custom names
+  - ARM Template generation - uses custom names for network adapter names
+  - All generated reports and diagrams
+
+- **Preserved When Changing Port Count** - If you change the number of ports, existing custom names are preserved for ports that still exist.
+
+- **Visual Indicator** - Ports with custom names display a blue border and "custom" badge for easy identification.
+
+- **ARM Compatibility** - Custom names are automatically sanitized for ARM template compatibility (special characters converted to underscores).
+
+---
+
 ## [0.12.6] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.12.6
+## Version 0.13.0
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.12.6 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.0 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## New Feature: Custom Network Adapter Port Naming

Based on customer feedback, users can now customize network adapter port names to match their existing Windows naming conventions.

### How it works

1. **Port Configuration (Step 07)** - Click on any port name to rename it (e.g., 'Slot3-Port1', 'NIC-MGMT-01', etc.)
2. **Adapter Mapping (Step 08)** - Custom names automatically appear in the adapter chips
3. **ARM Template** - Generated ARM parameters use the custom names for network adapters
4. **Reports/Diagrams** - All generated content uses the custom names

### Features

- **Click-to-edit** - Simply click on a port name to rename it
- **Visual indicators** - Ports with custom names show a blue border and 'custom' badge
- **Preserved on port count change** - If you change port count, existing custom names are kept
- **ARM sanitization** - Special characters are automatically converted to underscores for ARM compatibility
- **No validation** - Maximum flexibility for naming (up to 30 characters)

### Technical Changes

- Added \getPortDisplayName()\ helper function for consistent name retrieval
- Updated \enderPortConfiguration()\ with editable input field
- Updated \updatePortConfig()\ to handle \customName\ property
- Updated \uildAdapterPill()\ to display custom names
- Updated \rmAdapterNameForNic()\ to use custom names in ARM output
- Modified portConfig initialization to preserve existing configs when count changes