### PR TITLE
v0.13.4: Fix custom names in storageNetworkList, report, and diagram fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.4] - 2026-02-05
+
+### Fixed
+
+#### Custom Port Names in ARM storageNetworkList
+
+- **ARM Template Storage Network Names** - The `networkAdapterName` property in `storageNetworkList` now uses customer-provided custom port names instead of hardcoded "SMB1", "SMB2", etc.
+
+- **Applies to All Switchless Configurations** - 2-node, 3-node, and 4-node switchless storage configurations now correctly use custom SMB adapter names.
+
+- **Switched Storage Networks** - Regular (switched) storage network1/network2 sections also use custom port names.
+
+#### Report Host Networking Section
+
+- **Storage Adapter IPs Use Custom Names** - The Host Networking "Storage Adapter IPs" section in reports now displays custom port names instead of hardcoded SMB labels.
+
+#### Diagram Font Sizes for Long Custom Names
+
+- **Smaller Font in Adapter Tiles** - Reduced font size from 12px to 9px in NIC and SMB adapter tiles within switchless diagrams to accommodate longer custom port names.
+
+---
+
 ## [0.13.3] - 2026-02-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.3
+## Version 0.13.4
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.3 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.4 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/report.js
+++ b/report.js
@@ -2616,7 +2616,7 @@
                     function nicTile(x, y, label) {
                         var t = '';
                         t += '<rect x="' + x + '" y="' + y + '" width="' + nicW + '" height="' + nicH + '" rx="8" fill="rgba(0,120,212,0.20)" stroke="rgba(0,120,212,0.55)" />';
-                        t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 22) + '" text-anchor="middle" font-size="12" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
+                        t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 22) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
                         return t;
                     }
 
@@ -2698,7 +2698,7 @@
                         var tr2 = storageTileRect2(i2, p2);
                         var lbl2 = getPortCustomName(state, p2 + 1, 'smb');
                         svg2 += '<rect x="' + tr2.x + '" y="' + tr2.y + '" width="' + tr2.w + '" height="' + tr2.h + '" rx="8" fill="rgba(139,92,246,0.25)" stroke="rgba(139,92,246,0.65)" />';
-                        svg2 += '<text x="' + (tr2.x + tr2.w / 2) + '" y="' + (tr2.y + 24) + '" text-anchor="middle" font-size="12" fill="var(--text-primary)" font-weight="700">' + escapeHtml(lbl2) + '</text>';
+                        svg2 += '<text x="' + (tr2.x + tr2.w / 2) + '" y="' + (tr2.y + 24) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(lbl2) + '</text>';
                     }
                 }
 
@@ -2800,7 +2800,7 @@
                         function nicTile(x, y, label) {
                             var t = '';
                             t += '<rect x="' + x + '" y="' + y + '" width="' + nicW + '" height="' + nicH + '" rx="8" fill="rgba(0,120,212,0.20)" stroke="rgba(0,120,212,0.55)" />';
-                            t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 22) + '" text-anchor="middle" font-size="12" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
+                            t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 22) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
                             return t;
                         }
 
@@ -2881,7 +2881,7 @@
                             var trS = storageTileRectS(iS, pS);
                             var labelS = getPortCustomName(state, pS + 1, 'smb');
                             svgS += '<rect x="' + trS.x + '" y="' + trS.y + '" width="' + trS.w + '" height="' + trS.h + '" rx="8" fill="rgba(139,92,246,0.25)" stroke="rgba(139,92,246,0.65)" />';
-                            svgS += '<text x="' + (trS.x + trS.w / 2) + '" y="' + (trS.y + 24) + '" text-anchor="middle" font-size="12" fill="var(--text-primary)" font-weight="700">' + escapeHtml(labelS) + '</text>';
+                            svgS += '<text x="' + (trS.x + trS.w / 2) + '" y="' + (trS.y + 24) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(labelS) + '</text>';
                         }
                     }
 
@@ -3007,7 +3007,7 @@
                     function nicTile(x, y, label) {
                         var t = '';
                         t += '<rect x="' + x + '" y="' + y + '" width="' + nicW + '" height="' + nicH + '" rx="8" fill="rgba(0,120,212,0.20)" stroke="rgba(0,120,212,0.55)" />';
-                        t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 22) + '" text-anchor="middle" font-size="12" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
+                        t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 22) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
                         return t;
                     }
                     out += nicTile(nic1X, nicY, getNicLabel(1));
@@ -3096,7 +3096,7 @@
                         var tr = storageTileRect(i3, p3);
                         var label = getPortCustomName(state, p3 + 1, 'smb');
                         svg3 += '<rect x="' + tr.x + '" y="' + tr.y + '" width="' + tr.w + '" height="' + tr.h + '" rx="8" fill="rgba(139,92,246,0.25)" stroke="rgba(139,92,246,0.65)" />';
-                        svg3 += '<text x="' + (tr.x + tr.w / 2) + '" y="' + (tr.y + 24) + '" text-anchor="middle" font-size="12" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
+                        svg3 += '<text x="' + (tr.x + tr.w / 2) + '" y="' + (tr.y + 24) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
                     }
                 }
 
@@ -3205,7 +3205,7 @@
                     function nicTile(x, y, label) {
                         var t = '';
                         t += '<rect x="' + x + '" y="' + y + '" width="' + nicW + '" height="' + nicH + '" rx="8" fill="rgba(0,120,212,0.20)" stroke="rgba(0,120,212,0.55)" />';
-                        t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 22) + '" text-anchor="middle" font-size="12" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
+                        t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 22) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(label) + '</text>';
                         return t;
                     }
 
@@ -3362,7 +3362,7 @@
                         var tr4 = storageTileRect4(i4, p4);
                         var lbl4 = getPortCustomName(state, p4 + 1, 'smb');
                         svg4 += '<rect x="' + tr4.x + '" y="' + tr4.y + '" width="' + tr4.w + '" height="' + tr4.h + '" rx="8" fill="rgba(139,92,246,0.25)" stroke="rgba(139,92,246,0.65)" />';
-                        svg4 += '<text x="' + (tr4.x + tr4.w / 2) + '" y="' + (tr4.y + 24) + '" text-anchor="middle" font-size="12" fill="var(--text-primary)" font-weight="700">' + escapeHtml(lbl4) + '</text>';
+                        svg4 += '<text x="' + (tr4.x + tr4.w / 2) + '" y="' + (tr4.y + 24) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(lbl4) + '</text>';
                     }
                 }
 
@@ -4576,7 +4576,8 @@
                                     var nodeIps = [];
                                     nodeIps.push(getNodeName(0) + ': ' + prefix + '.2');
                                     nodeIps.push(getNodeName(1) + ': ' + prefix + '.3');
-                                    storageIpDetails.push('SMB' + (smbIdx + 1) + ': ' + nodeIps.join(', '));
+                                    var smbName = getPortCustomName(s, smbIdx + 1, 'smb');
+                                    storageIpDetails.push(smbName + ': ' + nodeIps.join(', '));
                                 }
                             }
                         } else if (nodeCount === 3) {
@@ -4598,7 +4599,8 @@
                                     }
                                 }
                                 if (nodeIps.length > 0) {
-                                    storageIpDetails.push('SMB' + smbIdx + ': ' + nodeIps.join(', '));
+                                    var smbName = getPortCustomName(s, smbIdx, 'smb');
+                                    storageIpDetails.push(smbName + ': ' + nodeIps.join(', '));
                                 }
                             }
                         } else if (nodeCount === 4) {
@@ -4621,7 +4623,8 @@
                                     }
                                 }
                                 if (nodeIps.length > 0) {
-                                    storageIpDetails.push('SMB' + smbIdx + ': ' + nodeIps.join(', '));
+                                    var smbName = getPortCustomName(s, smbIdx, 'smb');
+                                    storageIpDetails.push(smbName + ': ' + nodeIps.join(', '));
                                 }
                             }
                         }


### PR DESCRIPTION
## Changes

### Fixed

#### Custom Port Names in ARM storageNetworkList
- ARM Template Storage Network Names - The networkAdapterName property in storageNetworkList now uses customer-provided custom port names instead of hardcoded SMB1, SMB2, etc.
- Applies to All Switchless Configurations - 2-node, 3-node, and 4-node switchless storage configurations now correctly use custom SMB adapter names.
- Switched Storage Networks - Regular (switched) storage network1/network2 sections also use custom port names.

#### Report Host Networking Section
- Storage Adapter IPs Use Custom Names - The Host Networking Storage Adapter IPs section in reports now displays custom port names instead of hardcoded SMB labels.

#### Diagram Font Sizes for Long Custom Names
- Smaller Font in Adapter Tiles - Reduced font size from 12px to 9px in NIC and SMB adapter tiles within switchless diagrams to accommodate longer custom port names.