### PR TITLE
v0.13.5: Port Configuration UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.5] - 2026-02-05
+
+### Changed
+
+#### Port Configuration UX Improvements
+
+- **Read-Only Port Names by Default** - Port name inputs are now read-only by default. Users must click the pencil icon to enable editing, preventing accidental changes.
+
+- **Confirm Port Configuration Button** - Added a "Confirm Port Configuration" button that must be clicked before proceeding to Step 08 (Network Traffic Intents). This ensures users intentionally finalize their port settings.
+
+- **Edit Button for Confirmed Configuration** - After confirmation, a "✓ Port configuration confirmed" message appears with an "Edit" button to re-enable modifications if needed.
+
+- **Disabled State When Confirmed** - All port configuration controls (name, speed, RDMA) are disabled after confirmation to prevent unintended changes.
+
+- **Automatic Confirmation Reset** - Confirmation is automatically reset when port count changes or when earlier configuration choices affect port settings.
+
+---
+
 ## [0.13.4] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.4
+## Version 0.13.5
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.4 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.5 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>
@@ -1058,6 +1058,21 @@
                         <div id="rdma-validation-warning" class="info-box warning hidden" style="margin-top: 0.75rem;"></div>
                         <div id="port-config-grid" class="port-config-grid">
                             <!-- Dynamic Content -->
+                        </div>
+                        <div id="port-config-confirm-container" class="hidden" style="margin-top: 1.5rem; text-align: center;">
+                            <button id="port-config-confirm-btn" class="confirm-port-config-btn" onclick="confirmPortConfiguration()">
+                                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <polyline points="20 6 9 17 4 12"></polyline>
+                                </svg>
+                                Confirm Port Configuration
+                            </button>
+                            <p id="port-config-confirm-hint" style="margin-top: 0.5rem; font-size: 0.85rem; color: var(--text-secondary);">
+                                Click to confirm your port configuration before proceeding.
+                            </p>
+                        </div>
+                        <div id="port-config-confirmed-msg" class="hidden" style="margin-top: 1rem; text-align: center;">
+                            <span style="color: var(--accent-green); font-weight: 600;">✓ Port configuration confirmed</span>
+                            <button style="margin-left: 1rem; background: transparent; border: 1px solid var(--text-secondary); color: var(--text-secondary); padding: 4px 12px; border-radius: 4px; cursor: pointer; font-size: 0.85rem;" onclick="editPortConfiguration()">Edit</button>
                         </div>
                     </div>
                 </section>

--- a/style.css
+++ b/style.css
@@ -1691,6 +1691,43 @@ header .header-description {
     border-top-color: var(--accent-purple);
 }
 
+/* Port config confirmed state */
+.port-config-card.confirmed {
+    opacity: 0.7;
+    pointer-events: none;
+}
+
+.port-config-card.confirmed .speed-select,
+.port-config-card.confirmed .rdma-checkbox {
+    opacity: 0.6;
+}
+
+/* Confirm Port Configuration Button */
+.confirm-port-config-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: linear-gradient(135deg, var(--accent-purple), var(--accent-blue));
+    color: white;
+    border: none;
+    padding: 12px 28px;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 12px rgba(139, 92, 246, 0.3);
+}
+
+.confirm-port-config-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(139, 92, 246, 0.4);
+}
+
+.confirm-port-config-btn:active {
+    transform: translateY(0);
+}
+
 /* Intent Overrides (Layer 7) */
 .intent-overrides {
     margin-top: 1.25rem;


### PR DESCRIPTION
## Changes

### Changed

#### Port Configuration UX Improvements

- **Read-Only Port Names by Default** - Port name inputs are now read-only by default. Users must click the pencil icon to enable editing, preventing accidental changes.

- **Confirm Port Configuration Button** - Added a 'Confirm Port Configuration' button that must be clicked before proceeding to Step 08 (Network Traffic Intents). This ensures users intentionally finalize their port settings.

- **Edit Button for Confirmed Configuration** - After confirmation, a ' Port configuration confirmed' message appears with an 'Edit' button to re-enable modifications if needed.

- **Disabled State When Confirmed** - All port configuration controls (name, speed, RDMA) are disabled after confirmation to prevent unintended changes.

- **Automatic Confirmation Reset** - Confirmation is automatically reset when port count changes or when earlier configuration choices affect port settings.