### PR TITLE
v0.13.6: Fix diagram adapter mapping and font sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.6] - 2026-02-05
+
+### Fixed
+
+#### Report Diagrams Honor Adapter Mapping
+
+- **Correct Intent Assignments in Diagrams** - Switched network diagrams now correctly display adapter-to-intent assignments based on the confirmed adapter mapping. Previously, diagrams assumed NICs 1-2 were always Management+Compute and NICs 3+ were Storage, ignoring user-defined mappings.
+
+- **Adapter Mapping Groups** - Added `getAdapterMappingGroups()` helper to build intent groups from `state.adapterMapping` when adapter mapping is confirmed.
+
+- **Smaller Font Size for Adapter Labels** - Reduced font size from 10-11px to 9px for adapter labels in switched network diagrams to accommodate longer custom port names.
+
+---
+
 ## [0.13.5] - 2026-02-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.5
+## Version 0.13.6
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.5 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.6 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.13.5';
+const WIZARD_VERSION = '0.13.6';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 


### PR DESCRIPTION
## Changes

### Fixed

#### Report Diagrams Honor Adapter Mapping

- **Correct Intent Assignments in Diagrams** - Switched network diagrams now correctly display adapter-to-intent assignments based on the confirmed adapter mapping. Previously, diagrams assumed NICs 1-2 were always Management+Compute and NICs 3+ were Storage, ignoring user-defined mappings.

- **Adapter Mapping Groups** - Added getAdapterMappingGroups() helper to build intent groups from state.adapterMapping when adapter mapping is confirmed.

- **Smaller Font Size for Adapter Labels** - Reduced font size from 10-11px to 9px for adapter labels in switched network diagrams to accommodate longer custom port names.