### PR TITLE
v0.13.7: Fix diagram port labels and text overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.7] - 2026-02-05
+
+### Fixed
+
+#### Diagram Port Labels and Text Overlap
+
+- **Physical Port Names in Diagrams** - All diagram rendering functions now consistently use `getNicLabel()` for physical port names. Previously, storage ports incorrectly used `getSmbLabel()` which returns virtual SMB adapter names instead of physical port names.
+
+- **Staggered Text Positioning** - Port name labels within adapter shapes are now staggered vertically (odd ports higher, even ports lower) to prevent overlapping text when using long custom port names.
+
+- **Consistent Fix Across Rendering Paths** - Applied fixes to `renderAdaptersHorizontal()` (both adapter mapping and default paths) and `renderCustomAdaptersHorizontal()` functions.
+
+---
+
 ## [0.13.6] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.6
+## Version 0.13.7
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.6 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.7 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/report.js
+++ b/report.js
@@ -1502,10 +1502,13 @@
                         var isStorage = grp && grp.isStorageLike;
                         var fill = isStorage ? 'rgba(139,92,246,0.25)' : 'rgba(0,120,212,0.20)';
                         var stroke = isStorage ? 'rgba(139,92,246,0.65)' : 'rgba(0,120,212,0.55)';
-                        var label = isStorage ? getSmbLabel(nicIdx) : getNicLabel(nicIdx);
+                        // Always use getNicLabel for physical port names (from portConfig)
+                        var label = getNicLabel(nicIdx);
+                        // Stagger text vertically - odd ports higher, even ports lower
+                        var textY = (i % 2 === 0) ? (y + 16) : (y + 28);
 
                         out += '<rect x="' + x + '" y="' + y + '" width="' + adapterW + '" height="' + adapterH + '" rx="6" fill="' + fill + '" stroke="' + stroke + '" />';
-                        out += '<text x="' + (x + adapterW / 2) + '" y="' + (y + 23) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="600">' + escapeHtml(label) + '</text>';
+                        out += '<text x="' + (x + adapterW / 2) + '" y="' + textY + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="600">' + escapeHtml(label) + '</text>';
 
                         adapterPositions.push({
                             nodeIdx: nodeIdx,
@@ -1554,10 +1557,13 @@
                     var isStorage = !isCustom && showStorageGroup && i >= 2;
                     var fill = isStorage ? 'rgba(139,92,246,0.25)' : 'rgba(0,120,212,0.20)';
                     var stroke = isStorage ? 'rgba(139,92,246,0.65)' : 'rgba(0,120,212,0.55)';
-                    var label = isStorage ? getSmbLabel(nicIdx) : getNicLabel(nicIdx);
+                    // Always use getNicLabel for physical port names
+                    var label = getNicLabel(nicIdx);
+                    // Stagger text vertically - odd ports higher, even ports lower
+                    var textY = (i % 2 === 0) ? (y + 16) : (y + 28);
 
                     out += '<rect x="' + x + '" y="' + y + '" width="' + adapterW + '" height="' + adapterH + '" rx="6" fill="' + fill + '" stroke="' + stroke + '" />';
-                    out += '<text x="' + (x + adapterW / 2) + '" y="' + (y + 23) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="600">' + escapeHtml(label) + '</text>';
+                    out += '<text x="' + (x + adapterW / 2) + '" y="' + textY + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="600">' + escapeHtml(label) + '</text>';
 
                     // Store adapter center position for uplink drawing
                     adapterPositions.push({
@@ -1670,10 +1676,13 @@
                         stroke = 'rgba(0,120,212,0.55)';
                     }
 
-                    var label = isStorage ? getSmbLabel(nicIdx) : getNicLabel(nicIdx);
+                    // Always use getNicLabel for physical port names
+                    var label = getNicLabel(nicIdx);
+                    // Stagger text vertically - odd ports higher, even ports lower
+                    var textY = (i % 2 === 0) ? (y + 16) : (y + 28);
 
                     out += '<rect x="' + x + '" y="' + y + '" width="' + adapterW + '" height="' + adapterH + '" rx="6" fill="' + fill + '" stroke="' + stroke + '" />';
-                    out += '<text x="' + (x + adapterW / 2) + '" y="' + (y + 23) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="600">' + escapeHtml(label) + '</text>';
+                    out += '<text x="' + (x + adapterW / 2) + '" y="' + textY + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="600">' + escapeHtml(label) + '</text>';
 
                     // Store adapter center position for uplink drawing
                     adapterPositions.push({

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.13.6';
+const WIZARD_VERSION = '0.13.7';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 


### PR DESCRIPTION
## Changes

- **Physical Port Names in Diagrams** - All diagram rendering functions now consistently use getNicLabel() for physical port names. Previously, storage ports incorrectly used getSmbLabel() which returns virtual SMB adapter names.

- **Staggered Text Positioning** - Port name labels within adapter shapes are now staggered vertically (odd ports higher, even ports lower) to prevent overlapping text when using long custom port names.

- **Consistent Fix Across Rendering Paths** - Applied fixes to renderAdaptersHorizontal() (both adapter mapping and default paths) and renderCustomAdaptersHorizontal() functions.