### PR TITLE
v0.13.8: Fix StorageNetwork2 custom port name in ARM template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.8] - 2026-02-05
+
+### Fixed
+
+#### ARM StorageNetwork2 Custom Port Name
+
+- **StorageNetwork2 networkAdapterName** - Fixed switched storage ARM template generation where `StorageNetwork2` was incorrectly using hardcoded "SMB2" instead of the custom port name. The port index calculation in `armAdapterNameForSmb()` was off by one for the second storage network.
+
+---
+
 ## [0.13.7] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.7
+## Version 0.13.8
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.7 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.8 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.13.7';
+const WIZARD_VERSION = '0.13.8';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -1980,7 +1980,7 @@ function generateArmParameters() {
             if (storageNetworkCount >= 2) {
                 const network2 = {
                     name: 'StorageNetwork2',
-                    networkAdapterName: nic2 ? armAdapterNameForSmb(2, nic2 - 1) : 'REPLACE_WITH_STORAGE_ADAPTER_2',
+                    networkAdapterName: nic2 ? armAdapterNameForSmb(1, nic2 - 1) : 'REPLACE_WITH_STORAGE_ADAPTER_2',
                     vlanId: (storageVlan2 !== null && storageVlan2 !== undefined) ? String(storageVlan2) : 'REPLACE_WITH_STORAGE_VLAN_2'
                 };
                 if (includeStorageAdapterIPInfo) {


### PR DESCRIPTION
Fixed switched storage ARM template generation where StorageNetwork2 was incorrectly using hardcoded SMB2 instead of the custom port name.