### PR TITLE
v0.13.10: Fix Rack Aware diagram port name overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.10] - 2026-02-05
+
+### Fixed
+
+#### Rack Aware Diagram Port Name Overlap
+
+- **Staggered Text Positioning** - Port name labels in Rack Aware TOR diagrams are now staggered vertically within the adapter tiles (first port higher at y+14, second port lower at y+22) to prevent overlapping text when using long custom port names.
+
+- **Applied to Both Intent Groups** - The staggered text fix applies to both Mgmt+Compute and Storage (RDMA) intent groups.
+
+---
+
 ## [0.13.9] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.9
+## Version 0.13.10
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.9 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.10 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/report.js
+++ b/report.js
@@ -2104,15 +2104,17 @@
                 // Place intent text below the ports so cabling above stays readable.
                 out += '<text x="' + (setX + setW / 2) + '" y="' + setLabelY + '" text-anchor="middle" font-size="10" fill="var(--text-secondary)">' + escapeHtml(setLabelText) + '</text>';
 
-                function nicTile(x, y, labelText) {
+                function nicTile(x, y, labelText, idx) {
                     var t = '';
+                    // Stagger text vertically - first port higher, second port lower
+                    var textY = (idx % 2 === 0) ? (y + 14) : (y + 22);
                     t += '<rect x="' + x + '" y="' + y + '" width="' + nicW + '" height="' + nicH + '" rx="8" fill="rgba(0,120,212,0.20)" stroke="rgba(0,120,212,0.55)" />';
-                    t += '<text x="' + (x + nicW / 2) + '" y="' + (y + 19) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(labelText) + '</text>';
+                    t += '<text x="' + (x + nicW / 2) + '" y="' + textY + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(labelText) + '</text>';
                     return t;
                 }
 
-                out += nicTile(nic1X, nicY, getNicLabel(mgmtComputePorts[0] || 1));
-                out += nicTile(nic2X, nicY, getNicLabel(mgmtComputePorts[1] || 2));
+                out += nicTile(nic1X, nicY, getNicLabel(mgmtComputePorts[0] || 1), 0);
+                out += nicTile(nic2X, nicY, getNicLabel(mgmtComputePorts[1] || 2), 1);
 
                 return {
                     html: out,
@@ -2170,8 +2172,10 @@
                     // Use the actual storage port index from storagePorts array
                     var portIdx = storagePorts[iS] || (iS + 3);
                     var lbl = getNicLabel(portIdx);
+                    // Stagger text vertically - first port higher, second port lower
+                    var textY = (iS % 2 === 0) ? (yS + 14) : (yS + 22);
                     out += '<rect x="' + xS + '" y="' + yS + '" width="' + tileW + '" height="' + tileH + '" rx="8" fill="rgba(139,92,246,0.25)" stroke="rgba(139,92,246,0.65)" />';
-                    out += '<text x="' + (xS + tileW / 2) + '" y="' + (yS + 19) + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(lbl) + '</text>';
+                    out += '<text x="' + (xS + tileW / 2) + '" y="' + textY + '" text-anchor="middle" font-size="9" fill="var(--text-primary)" font-weight="700">' + escapeHtml(lbl) + '</text>';
                     // Port anchors on the outside/top edge of each SMB tile (horizontally centered).
                     portsOut.push({ idx: portIdx, x: xS + Math.floor(tileW / 2), y: yS - 1 });
                 }

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.13.9';
+const WIZARD_VERSION = '0.13.10';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 


### PR DESCRIPTION
Added staggered text positioning to port tiles in Rack Aware diagrams to prevent long custom port names from overlapping.