### PR TITLE
v0.13.14: Fix diagram intent boxes for non-contiguous adapter mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.14] - 2026-02-05
+
+### Fixed
+
+#### Diagram Intent Box Rendering for Non-Contiguous Adapter Mapping
+
+- Fixed switched storage diagram to correctly render intent group boxes when adapter mapping has non-contiguous NICs
+- Previously, if Mgmt+Compute used NICs 1 and 3 while Storage used NICs 2 and 4 (interleaved), the intent boxes would incorrectly span from NIC 1-3 and 2-4, overlapping each other
+- Now correctly renders separate boxes for each contiguous run of NICs within an intent group
+- Properly handles any custom adapter mapping configuration with non-adjacent port assignments
+
+---
+
 ## [0.13.13] - 2026-02-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.13
+## Version 0.13.14
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.13 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.14 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.13.13';
+const WIZARD_VERSION = '0.13.14';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 


### PR DESCRIPTION
## Problem

When adapter mapping has non-contiguous NICs (e.g., Mgmt+Compute using NICs 1 and 3, Storage using NICs 2 and 4), the intent group boxes in the switched diagram were incorrectly drawn spanning from min to max NIC positions, causing overlap.

## Solution

Updated the rendering logic to detect contiguous runs of NICs within each intent group and draw separate boxes for each run.

Now correctly handles interleaved adapter configurations like:
- Mgmt+Compute: Slot-0-Port-1, Slot-1-Port-1 (NICs 1, 3)
- Storage: Slot-0-Port-2, Slot-1-Port-2 (NICs 2, 4)