### PR TITLE
v0.13.15: Auto-confirm configurations when importing ARM templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.15] - 2026-02-05
+
+### Improved
+
+#### ARM Template Import Auto-Confirmation
+
+- When importing ARM templates from existing deployments, wizard now auto-confirms:
+  - Port configuration (portConfigConfirmed)
+  - Adapter mapping for mgmt_compute intent (adapterMappingConfirmed)
+  - Intent overrides (overridesConfirmed)
+  - Custom storage subnets if present (customStorageSubnetsConfirmed)
+- Removes unnecessary manual confirmations when importing a template from a working deployment
+- Auto-builds adapter mapping for mgmt_compute intent based on port count (first 2 for mgmt, remaining for storage)
+
+---
+
 ## [0.13.14] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.14
+## Version 0.13.15
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.14 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.15 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Problem

When importing ARM templates from existing Azure deployments, the wizard was requiring users to manually confirm port configuration, adapter mapping, and overrides even though the template contains complete deployment information.

## Solution

The wizard now auto-confirms the following when importing ARM templates:
- Port configuration
- Adapter mapping (for mgmt_compute intent)
- Intent overrides
- Custom storage subnets (if present)

This streamlines the import workflow for existing deployments while still allowing users to customize Arc Gateway, Proxy, and SDN settings through the import dialog.