### PR TITLE
v0.13.16: Fix diagram intent grouping for non-contiguous adapter mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.16] - 2026-02-05
+
+### Fixed
+
+#### Diagram Intent Grouping for Non-Contiguous Adapter Mapping
+
+- Fixed switched storage diagram to properly group ports by intent visually
+- When adapter mapping has non-contiguous NICs (e.g., Mgmt+Compute using NICs 1,3 and Storage using NICs 2,4), the diagram now:
+  - Groups all Mgmt+Compute ports together on the left with a labeled dotted blue box
+  - Groups all Storage ports together on the right with a labeled dotted purple box
+  - Displays ports in logical groups rather than physical port order
+- Both intent groups now have properly labeled boxes (previously only Storage had a label)
+
+---
+
 ## [0.13.15] - 2026-02-05
 
 ### Improved

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.15
+## Version 0.13.16
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.15 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.16 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.13.15';
+const WIZARD_VERSION = '0.13.16';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 


### PR DESCRIPTION
## Problem

When adapter mapping has non-contiguous NICs (e.g., Mgmt+Compute using NICs 1,3 and Storage using NICs 2,4), the diagram was showing separate boxes for each port and missing the Mgmt+Compute label.

## Solution

The diagram now properly groups ports by intent:
- All Mgmt+Compute ports are grouped together on the left with a labeled dotted blue box
- All Storage ports are grouped together on the right with a labeled dotted purple box
- Ports are displayed in logical intent groups rather than physical port order
- Both intent groups now have properly labeled boxes