### PR TITLE
v0.13.17: Fix diagram uplink connections based on intent group position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.17] - 2026-02-05
+
+### Fixed
+
+#### Diagram Uplink Connections Based on Intent Group Position
+
+- Fixed ToR switch uplink connections to use position within intent group instead of physical NIC index
+- First port of each intent group now correctly connects to ToR Switch 1
+- Second port of each intent group now correctly connects to ToR Switch 2
+- Applied fix to all switched diagram scenarios:
+  - Standard adapter mapping (mgmt_compute intent)
+  - Default port layout (NICs 1-2 Mgmt+Compute, NICs 3+ Storage)
+  - Custom intent configurations
+
+---
+
 ## [0.13.16] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.16
+## Version 0.13.17
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.16 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.17 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.13.16';
+const WIZARD_VERSION = '0.13.17';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 


### PR DESCRIPTION
## Problem

ToR switch uplink connections were using physical NIC index to determine which ToR to connect to, resulting in incorrect cable routing when adapter mapping reorders ports.

## Solution

Uplink connections now use position within intent group:
- First port of each intent group  ToR Switch 1
- Second port of each intent group  ToR Switch 2

Applied to all switched diagram scenarios:
- Adapter mapping (mgmt_compute intent)
- Default port layout (NICs 1-2 Mgmt+Compute, NICs 3+ Storage)
- Custom intent configurations