### PR TITLE
v0.13.18: Fix ARM import adapter mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.18] - 2026-02-05
+
+### Fixed
+
+#### ARM Template Import Adapter Mapping
+
+- Fixed ARM template import to properly parse adapter mapping from intentList
+- When importing templates with mgmt_compute intent, both NIC and SMB adapters are now correctly mapped
+- NIC adapters (from Compute_Management intent) are mapped to Management + Compute zone
+- SMB adapters (from Storage intent) are mapped to Storage zone
+- Port count now correctly includes both NIC and SMB adapter counts
+
+---
+
 ## [0.13.17] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.17
+## Version 0.13.18
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.17 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.18 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.13.17';
+const WIZARD_VERSION = '0.13.18';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -8194,6 +8194,16 @@ function parseArmTemplateToState(armTemplate) {
                 });
                 // Update port count to include storage ports
                 result.ports = String(nicAdapters.length + smbAdapters.length);
+                
+                // Build adapter mapping from intent list
+                // NIC adapters (1-based indices) go to 'mgmt', SMB adapters go to 'storage'
+                result.adapterMapping = {};
+                for (let i = 1; i <= nicAdapters.length; i++) {
+                    result.adapterMapping[i] = 'mgmt';
+                }
+                for (let i = 1; i <= smbAdapters.length; i++) {
+                    result.adapterMapping[nicAdapters.length + i] = 'storage';
+                }
             }
             
             // If no NIC adapters but we have SMB adapters, create ports from SMB count


### PR DESCRIPTION
When importing ARM templates from existing deployments, the adapter mapping now properly parses both Management+Compute (NIC adapters) and Storage (SMB adapters) from the intentList. Previously only Storage ports were showing in the adapter mapping UI.