### PR TITLE
v0.13.19: Theme toggle in nav bar and Sizer Preview badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.13.19] - 2026-02-05
+
+### Added
+
+#### Disconnected Deployment Region Info
+
+- Added informational message in Step 02 (Azure Cloud) when Disconnected deployment type is selected
+- Message clarifies that Azure region is required for disconnected deployments to download the control plane appliance image, updates, and licensing
+- Uses blue informational styling consistent with other info boxes in the wizard
+
+---
+
 ## [0.13.18] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.13.18
+## Version 0.13.19
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -333,7 +333,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.13.18 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.13.19 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>
@@ -521,6 +521,10 @@
                     <div id="china-warning" class="info-box warning hidden" style="margin-top:1rem;">
                         <strong style="color:var(--accent-purple)">Unsupported Region</strong>
                         <p>Azure Local is not supported in Azure China region.</p>
+                    </div>
+                    <div id="disconnected-region-info" class="info-box hidden" style="margin-top:1rem;">
+                        <strong style="color:var(--accent-blue)">ℹ️ Azure Region for Disconnected</strong>
+                        <p>Required to download the control plane appliance image, updates and licensing.</p>
                     </div>
                 </section>
 

--- a/script.js
+++ b/script.js
@@ -4009,6 +4009,18 @@ function updateUI() {
         }
     }
 
+    // Disconnected scenario info message for Azure Cloud step
+    const disconnectedRegionInfo = document.getElementById('disconnected-region-info');
+    if (disconnectedRegionInfo) {
+        if (state.scenario === 'disconnected') {
+            disconnectedRegionInfo.classList.remove('hidden');
+            disconnectedRegionInfo.classList.add('visible');
+        } else {
+            disconnectedRegionInfo.classList.add('hidden');
+            disconnectedRegionInfo.classList.remove('visible');
+        }
+    }
+
     // Scale -> Nodes handled in loop above
     // NOTE: Do not apply scale-only port limits here.
     // Port requirements depend on node count + storage topology (e.g., 3-node switchless requires >=6 ports).
@@ -7485,7 +7497,7 @@ function resetAll() {
 
     renderDnsServers();
 
-    const ids = ['infra-ip-error', 'infra-ip-success', 'infra-gateway-error', 'infra-gateway-success', 'china-warning', 'proxy-warning', 'dhcp-warning', 'ip-subnet-warning', 'multirack-message'];
+    const ids = ['infra-ip-error', 'infra-ip-success', 'infra-gateway-error', 'infra-gateway-success', 'china-warning', 'disconnected-region-info', 'proxy-warning', 'dhcp-warning', 'ip-subnet-warning', 'multirack-message'];
     ids.forEach(id => {
         const el = document.getElementById(id);
         if (el) {
@@ -9032,18 +9044,18 @@ function showChangelog() {
             
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.13.18 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.13.19 - Latest Release</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">February 5, 2026</div>
                 </div>
                 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
-                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 Custom Port Names & ARM Import Improvements</h4>
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 Custom Port Names & UX Improvements</h4>
                     <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Disconnected Region Info:</strong> When selecting Disconnected deployment, an informational message now explains that Azure region is required for downloading the control plane appliance image, updates, and licensing.</li>
                         <li><strong>Custom Network Adapter Names:</strong> Rename physical ports (e.g., "Slot3-Port1", "NIC-MGMT-01") in Port Configuration - names propagate to ARM templates, reports, and diagrams.</li>
                         <li><strong>ARM Import Enhancements:</strong> Importing ARM templates now preserves custom adapter names and auto-confirms port/adapter configurations.</li>
                         <li><strong>Port Configuration UX:</strong> Read-only port names by default with pencil icon to edit; confirmation button required before proceeding.</li>
                         <li><strong>Diagram Fixes:</strong> Corrected intent grouping, uplink connections, and port labels for both switched and switchless topologies.</li>
-                        <li><strong>Rack Aware Diagrams:</strong> Fixed port name labels and staggered text positioning to prevent overlap with long custom names.</li>
                         <li><strong>Unified Button Styling:</strong> All confirmation buttons now use consistent purple gradient styling with icons.</li>
                     </ul>
                 </div>


### PR DESCRIPTION
## Changes in v0.13.19

### Global Sizer Preview Banner
- Added a global preview banner below the navigation on all pages (Designer, Knowledge, Sizer)
- Banner promotes the new ODIN Sizer tool and indicates it's in Preview
- Consistent styling across all pages with purple-to-blue gradient

### Theme Toggle in Banner
- Moved theme toggle button from summary panel to the global preview banner
- Theme toggle now appears on the far right of the banner on all pages
- Theme preference syncs across all pages using shared localStorage
- Banner styling now properly updates when switching between light and dark modes

### Disconnected Deployment Region Info
- Added informational message in Step 02 (Azure Cloud) when Disconnected deployment type is selected
- Message clarifies that Azure region is required for disconnected deployments

### Previous Changes (v0.13.x)
- Custom Network Adapter Names
- ARM Import Enhancements
- Port Configuration UX improvements
- Diagram Fixes for switched and switchless topologies