### PR TITLE
Fix ARM import adapter names and single-node diagram (v0.14.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.2] - 2026-02-05
+
+### Fixed
+
+#### ARM Template Import - Adapter Names and Diagram
+
+- **Adapter Names Preserved**: Importing ARM templates now preserves adapter names (NIC1, NIC2, SMB1, SMB2, etc.) from the template instead of displaying generic "Port 1", "Port 2" labels
+- **Single-Node Diagram**: Fixed issue where host networking diagram was not displaying in the configuration report for single-node deployments (diagram extraction was missing 'Network Connectivity (Diagram)' title)
+
+---
+
 ## [0.14.1] - 2026-02-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.14.1
+## Version 0.14.2
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 

--- a/index.html
+++ b/index.html
@@ -352,7 +352,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.14.1 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
+                        Version 0.14.2 | <a href="#" onclick="event.preventDefault(); showChangelog();" style="color: var(--accent-blue); text-decoration: none;">What's New</a>
                     </div>
                 </div>
             </div>

--- a/report.js
+++ b/report.js
@@ -5047,8 +5047,9 @@
                 // Pull either diagram (only one should apply for a given storage selection).
                 var swl = extractDiagramBodyByTitle('Switchless Storage Connectivity (Diagram)');
                 var swd = extractDiagramBodyByTitle('Switched Connectivity (Diagram)');
+                var snc = extractDiagramBodyByTitle('Network Connectivity (Diagram)');  // Single-node clusters
                 var rac = extractDiagramBodyByTitle('Rack Aware TOR Architecture (Diagram)');
-                movedDiagramInnerHtml = (swl || rac || swd || '');
+                movedDiagramInnerHtml = (swl || rac || swd || snc || '');
 
                 ratEl.innerHTML = wrap ? wrap.innerHTML : rationaleHtml;
             } catch (e) {


### PR DESCRIPTION
Fixes ARM template import: preserves adapter names (NIC1/NIC2/SMB1/SMB2) and adds single-node diagram to configuration report.