### PR TITLE
fix(analytics): Add initializeAnalytics() to sizer and docs pages

### DIFF
--- a/docs/outbound-connectivity/script.js
+++ b/docs/outbound-connectivity/script.js
@@ -1,6 +1,9 @@
 // Smooth scroll and active navigation highlighting
 document.addEventListener('DOMContentLoaded', function() {
-    // Track page view for analytics
+    // Initialize and track page view for analytics
+    if (typeof initializeAnalytics === 'function') {
+        initializeAnalytics();
+    }
     if (typeof trackPageView === 'function') {
         trackPageView();
     }

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -2,7 +2,10 @@
 // ODIN Sizer - JavaScript
 // ============================================
 
-// Track page view for analytics
+// Initialize and track page view for analytics
+if (typeof initializeAnalytics === 'function') {
+    initializeAnalytics();
+}
 if (typeof trackPageView === 'function') {
     trackPageView();
 }


### PR DESCRIPTION
Fixes Firebase analytics not tracking page views on sizer and docs/outbound-connectivity pages.

The pages had analytics.js loaded but weren't calling initializeAnalytics() before trackPageView(), so tracking was silently skipped.