### PR TITLE
docs: update README, CHANGELOG, and What's New for 0.14.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Real-time Feedback**: The inline field validators for `ipv4cidr` and `ipv4` types now show specific error messages when a network or broadcast address is entered.
 - **Utility Functions**: Added `isNetworkOrBroadcastAddress()` for CIDR-aware validation and `isLastOctetNetworkOrBroadcast()` for bare IP checks.
 
+#### Switchless Storage Intent Adapter Names
+
+- **Intent List Adapter Names**: Fixed ARM `intentList` where switchless storage adapters were named `SMB1`, `SMB2`, etc. instead of using the wizard's port display names (`Port 3`, `Port 4`, etc.). Refactored `getStorageAdapterNamesForIntent()` to delegate to `armAdapterNameForSmb()` instead of duplicating logic with hardcoded "SMB" fallback.
+
+#### DNS Validation Blocks Report Generation
+
+- **DNS Validation Gating**: DNS server validation (network/broadcast address checks) now blocks report and ARM generation instead of only showing a warning.
+
 ### Improved
 
 #### Port Name Consistency Across All Outputs
 
-- **ARM Adapter Names**: ARM parameter file adapter names now use the wizard's port display names (e.g., `Port_1`, `Port_2`) instead of generic `NIC1`/`SMB1` prefixes, matching what users see in the wizard UI.
+- **ARM Adapter Names**: ARM parameter file adapter names now use the wizard's port display names (e.g., `Port 1`, `Port 2`) instead of generic `NIC1`/`SMB1` prefixes, matching what users see in the wizard UI. JSON strings support spaces, so no sanitization is applied.
 - **Configuration Summary Labels**: The sidebar Configuration Summary now displays custom port names from `getPortDisplayName()` instead of hardcoded "NIC X" labels.
+
+#### CI Pipeline Hardening
+
+- **Blocking CI Jobs**: ESLint, unit tests, and HTML validation CI jobs now block pull request merges on failure (removed `continue-on-error`).
+- **HTML Validation**: Added automated HTML5 validation for all HTML files with `.htmlvalidate.json` configuration.
+- **197 Unit Tests**: Expanded test suite from 136 to 197 tests with regression coverage for all bug fixes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,16 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.14.52 - Latest Release
-- **Markdown Report Export**: New "Download Markdown" button on the Configuration Report page — export your full report as a `.md` file with embedded network diagrams for documentation, wikis, or version control
-- **Diagram Intent Grouping Fix**: Fixed network diagram to properly group adapters by intent when using custom intent configurations with non-contiguous port assignments
-- **Non-Contiguous Port Support**: Ports from different slots assigned to the same intent are now displayed adjacent to each other in the diagram
-- **Duplicate Adapter Name Validation**: Prevents duplicate adapter names in port configuration with visual feedback and validation warnings
+### 🎉 Version 0.14.53 - Latest Release
+- **ARM Storage Adapter Naming (#74)**: Fixed ARM template where both StorageNetwork1 and StorageNetwork2 used the same adapter name
+- **Switchless Intent Adapter Names**: Fixed ARM `intentList` using `SMB1`/`SMB2` instead of `Port 3`/`Port 4` for switchless storage
+- **VLAN ID Defaults of Zero (#75)**: Fixed empty string VLAN values producing invalid VLAN ID 0
+- **NIC Speed Locked on Single-Node (#76)**: Removed forced 10 GbE speed override on single-node clusters
+- **IP Address Validation (#78)**: Node IPs and DNS servers now reject network (.0) and broadcast (.255) addresses
+- **Port Name Consistency**: ARM adapter names now use wizard display names (`Port 1`, `Port 2`) instead of `NIC1`/`SMB1`
+- **DNS Validation Gating**: DNS validation now blocks report/ARM generation instead of warning only
+- **CI Pipeline Hardening**: ESLint, unit tests, and HTML validation are now blocking CI checks
+- **197 Unit Tests**: Expanded from 136 to 197 tests with regression coverage for all fixes
 
 > **Full Version History**: See [Appendix A - Version History](#appendix-a---version-history) for complete release notes.
 
@@ -402,6 +407,15 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.14.x Series (February 2026)
+
+#### 0.14.53 - Bug Fixes, Port Name Consistency & CI Hardening
+- **ARM Storage Adapter Naming (#74)**: Fixed ARM template adapter naming for StorageNetwork1/2
+- **Switchless Intent Adapter Names**: Fixed `intentList` using `SMB N` instead of `Port N` for switchless storage
+- **VLAN Defaults (#75)**: Fixed empty string VLAN values producing invalid VLAN ID 0
+- **NIC Speed (#76)**: Removed forced 10 GbE speed override on single-node clusters
+- **IP Validation (#78)**: Node IPs and DNS reject network/broadcast addresses
+- **Port Name Consistency**: ARM adapter names match wizard display names
+- **197 Unit Tests**: Expanded test suite with regression coverage
 
 #### 0.14.52 - Markdown Export, Diagram Fix & Validation
 - **Markdown Report Export**: Download the Configuration Report as a Markdown file with embedded network diagrams for documentation or version control

--- a/js/script.js
+++ b/js/script.js
@@ -8456,14 +8456,18 @@ function showChangelog() {
                         <li><strong>VLAN ID Defaults of Zero (#75):</strong> Fixed empty string and zero VLAN values being treated as valid, which produced invalid VLAN ID 0. Proper defaults (711/712) are now applied.</li>
                         <li><strong>NIC Speed Locked on Single-Node (#76):</strong> Removed forced 10 GbE speed override on single-node clusters, allowing users to retain their selected NIC speed.</li>
                         <li><strong>IP Address Validation (#78):</strong> Node IPs, DNS servers, and inline validators now reject network (.0) and broadcast (.255) addresses with clear error messages.</li>
+                        <li><strong>Switchless Intent Adapters:</strong> Fixed ARM <code>intentList</code> where switchless storage adapters were named SMB1, SMB2 instead of using the wizard's port display names (Port 3, Port 4, etc.).</li>
                     </ul>
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
                     <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">✨ Improvements</h4>
                     <ul style="margin: 0; padding-left: 20px;">
-                        <li><strong>Port Name Consistency:</strong> ARM parameter file adapter names now match the wizard's port display names (e.g., Port_1, Port_2) instead of generic NIC1/SMB1 prefixes.</li>
+                        <li><strong>Port Name Consistency:</strong> ARM parameter file adapter names now match the wizard's port display names (e.g., Port 1, Port 2) instead of generic NIC1/SMB1 prefixes.</li>
                         <li><strong>Configuration Summary Labels:</strong> The sidebar Configuration Summary now shows custom port names instead of generic "NIC X" labels.</li>
+                        <li><strong>DNS Validation Gating:</strong> DNS server validation now blocks report and ARM generation instead of only showing a warning.</li>
+                        <li><strong>CI Pipeline Hardening:</strong> ESLint, unit tests, and HTML validation CI jobs now block pull request merges on failure.</li>
+                        <li><strong>197 Unit Tests:</strong> Expanded test suite from 136 to 197 tests with regression coverage for all bug fixes.</li>
                     </ul>
                 </div>
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect all fixes and improvements in version 0.14.53.

## Changes

### CHANGELOG.md
- Added switchless storage intent adapter fix (intentList using SMB N to Port N)
- Added DNS validation gating (blocks report/ARM generation instead of warning only)
- Added CI pipeline hardening (ESLint, unit tests, HTML validation now blocking)
- Updated test count from 136 to 197
- Fixed Port_1 to Port 1 (removed sanitization - JSON supports spaces)

### README.md
- Updated Latest Release section from 0.14.52 to 0.14.53 with all fixes
- Added 0.14.53 entry to Appendix A version history

### js/script.js (What's New dialog)
- Added switchless intent adapter fix
- Added DNS validation gating, CI hardening, 197 test count
- Fixed Port_1 to Port 1

## Testing
- All 197 tests pass
- Documentation-only changes (no functional code changes)