### PR TITLE
feat: shared nav component, feedback link, and sizer disclaimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improved
 
+#### Shared Navigation Component
+
+- **Centralized Nav Bar**: Extracted the duplicated navigation bar HTML from `index.html`, `sizer/index.html`, and `docs/outbound-connectivity/index.html` into a shared `js/nav.js` component. All pages now render the nav from a single source, ensuring consistency.
+- **Feedback Button**: Added a "💡 Feedback" link in the navigation bar (all pages) pointing to the GitHub Issues page for raising feedback or bugs.
+- **Sizer Disclaimer**: Added a disclaimer banner on the Sizer page noting that Sizer functionality is in active development and integration with the Designer wizard will be available in a future release.
+
 #### Port Name Consistency Across All Outputs
 
 - **ARM Adapter Names**: ARM parameter file adapter names now use the wizard's port display names (e.g., `Port 1`, `Port 2`) instead of generic `NIC1`/`SMB1` prefixes, matching what users see in the wizard UI. JSON strings support spaces, so no sanitization is applied.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Storage VLAN Placeholders**: Fixed ARM output showing `REPLACE_WITH_STORAGE_VLAN` instead of actual VLAN IDs for custom intent with adapter mapping
 - **Port Name Consistency**: ARM adapter names now use wizard display names (`Port 1`, `Port 2`) instead of `NIC1`/`SMB1`
 - **DNS Validation Gating**: DNS validation now blocks report/ARM generation instead of warning only
+- **Shared Navigation Bar**: Centralized nav bar across all pages via `js/nav.js` for consistent updates
+- **Feedback Button**: Added "💡 Feedback" link in the nav bar pointing to GitHub Issues
+- **Sizer Disclaimer**: Added development status notice on the Sizer page
 - **CI Pipeline Hardening**: ESLint, unit tests, and HTML validation are now blocking CI checks
 - **198 Unit Tests**: Expanded from 136 to 198 tests with regression coverage for all fixes
 
@@ -419,6 +422,7 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 - **Default Gateway Validation**: Fixed gateway validation warning on resume/load
 - **Storage VLAN Placeholders**: Fixed `REPLACE_WITH_STORAGE_VLAN` in ARM output for custom intent with adapter mapping
 - **Port Name Consistency**: ARM adapter names match wizard display names
+- **Shared Navigation Bar**: Centralized nav component across all pages with Feedback link
 - **198 Unit Tests**: Expanded test suite with regression coverage
 
 #### 0.14.52 - Markdown Export, Diagram Fix & Validation

--- a/docs/outbound-connectivity/index.html
+++ b/docs/outbound-connectivity/index.html
@@ -11,40 +11,9 @@
     <!-- Segoe UI is a Windows system font - no Google Fonts import needed -->
 </head>
 <body>
-    <!-- Tab Navigation (consistent with main site) -->
-    <nav class="odin-tab-nav">
-        <div class="odin-tab-container">
-            <a href="../../index.html" class="odin-tab-logo">
-                <img src="images/odin-logo.png" alt="Odin">
-                <span>ODIN</span>
-            </a>
-            <a href="../../index.html" class="odin-tab-btn" data-tab="designer">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <rect x="3" y="3" width="18" height="18" rx="2"/>
-                    <path d="M3 9h18M9 21V9"/>
-                </svg>
-                Designer
-            </a>
-            <a href="#" class="odin-tab-btn active" data-tab="knowledge">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
-                </svg>
-                Knowledge
-            </a>
-            <a href="../../sizer/index.html" class="odin-tab-btn" data-tab="sizer">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M3 3v18h18"/>
-                    <path d="M18 17V9"/>
-                    <path d="M13 17V5"/>
-                    <path d="M8 17v-3"/>
-                </svg>
-                Sizer
-                <span class="odin-tab-badge">Preview</span>
-            </a>
-            <button onclick="toggleTheme()" id="theme-toggle" class="nav-theme-toggle" title="Toggle light/dark theme">🌙</button>
-        </div>
-    </nav>
+    <!-- Tab Navigation (shared component) -->
+    <nav class="odin-tab-nav" id="odin-nav" data-active="knowledge" data-base="../../"></nav>
+    <script src="../../js/nav.js"></script>
 
     <nav class="sidebar">
         <div class="sidebar-header">

--- a/index.html
+++ b/index.html
@@ -247,40 +247,9 @@
 <body class="has-tab-nav">
     <div class="background-globes"></div>
 
-    <!-- Tab Navigation -->
-    <nav class="odin-tab-nav" aria-label="Main navigation">
-        <div class="odin-tab-container">
-            <div class="odin-tab-logo">
-                <img src="images/odin-logo.png" alt="Odin">
-                <span>ODIN</span>
-            </div>
-            <button type="button" class="odin-tab-btn active" data-tab="designer" onclick="switchOdinTab('designer')">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <rect x="3" y="3" width="18" height="18" rx="2"/>
-                    <path d="M3 9h18M9 21V9"/>
-                </svg>
-                Designer
-            </button>
-            <a href="docs/outbound-connectivity/index.html" class="odin-tab-btn" data-tab="knowledge">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
-                </svg>
-                Knowledge
-            </a>
-            <a href="sizer/index.html" class="odin-tab-btn" data-tab="sizer">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M3 3v18h18"/>
-                    <path d="M18 17V9"/>
-                    <path d="M13 17V5"/>
-                    <path d="M8 17v-3"/>
-                </svg>
-                Sizer
-                <span class="odin-tab-badge">Preview</span>
-            </a>
-            <button type="button" onclick="toggleTheme()" id="theme-toggle" class="nav-theme-toggle" title="Toggle light/dark theme">🌙</button>
-        </div>
-    </nav>
+    <!-- Tab Navigation (shared component) -->
+    <nav class="odin-tab-nav" id="odin-nav" data-active="designer" data-base="" aria-label="Main navigation"></nav>
+    <script src="js/nav.js"></script>
 
     <!-- Designer Tab Content -->
     <div id="tab-designer" class="odin-tab-content active">

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,97 @@
+/**
+ * Shared navigation bar component for all ODIN pages.
+ *
+ * Usage:
+ *   <nav id="odin-nav" data-active="designer" data-base=""></nav>
+ *   <script src="js/nav.js"></script>
+ *
+ *   data-active : "designer" | "knowledge" | "sizer"  (which tab is highlighted)
+ *   data-base   : relative path prefix to repo root, e.g. "" (root), "../" (sizer), "../../" (docs/outbound)
+ */
+(function () {
+    'use strict';
+
+    var nav = document.getElementById('odin-nav');
+    if (!nav) return;
+
+    var active = nav.getAttribute('data-active') || 'designer';
+    var base   = nav.getAttribute('data-base')   || '';
+
+    // Ensure base ends with '/' if non-empty
+    if (base && base.charAt(base.length - 1) !== '/') base += '/';
+
+    var svgDesigner  = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>';
+    var svgKnowledge = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>';
+    var svgSizer     = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/></svg>';
+
+    var tabs = [
+        {
+            id: 'designer',
+            label: 'Designer',
+            svg: svgDesigner,
+            href: base + 'index.html',
+            badge: null
+        },
+        {
+            id: 'knowledge',
+            label: 'Knowledge',
+            svg: svgKnowledge,
+            href: base + 'docs/outbound-connectivity/index.html',
+            badge: null
+        },
+        {
+            id: 'sizer',
+            label: 'Sizer',
+            svg: svgSizer,
+            href: base + 'sizer/index.html',
+            badge: 'Preview'
+        }
+    ];
+
+    // On the Designer page the Designer "tab" is a <button> that calls switchOdinTab,
+    // everywhere else it's a plain <a> link.
+    var html = '<div class="odin-tab-container">';
+
+    // Logo
+    if (active === 'designer') {
+        html += '<div class="odin-tab-logo">';
+    } else {
+        html += '<a href="' + base + 'index.html" class="odin-tab-logo">';
+    }
+    html += '<img src="' + base + 'images/odin-logo.png" alt="Odin">';
+    html += '<span>ODIN</span>';
+    html += active === 'designer' ? '</div>' : '</a>';
+
+    // Tab buttons
+    for (var i = 0; i < tabs.length; i++) {
+        var t = tabs[i];
+        var isActive = t.id === active;
+        var cls = 'odin-tab-btn' + (isActive ? ' active' : '');
+
+        if (active === 'designer' && t.id === 'designer') {
+            // On the main page, Designer tab is a <button> wired to switchOdinTab
+            html += '<button type="button" class="' + cls + '" data-tab="designer" onclick="switchOdinTab(\'designer\')">';
+        } else if (isActive) {
+            html += '<a href="#" class="' + cls + '" data-tab="' + t.id + '">';
+        } else {
+            html += '<a href="' + t.href + '" class="' + cls + '" data-tab="' + t.id + '">';
+        }
+
+        html += t.svg + ' ' + t.label;
+        if (t.badge) {
+            html += ' <span class="odin-tab-badge">' + t.badge + '</span>';
+        }
+
+        html += (active === 'designer' && t.id === 'designer') ? '</button>' : '</a>';
+    }
+
+    // Feedback link
+    html += '<a href="https://github.com/Azure/odinforazurelocal/issues" target="_blank" rel="noopener noreferrer" class="nav-theme-toggle" title="Raise feedback or issue" style="text-decoration: none; display: flex; align-items: center; gap: 6px;">\uD83D\uDCA1 Feedback</a>';
+
+    // Theme toggle
+    html += '<button type="button" onclick="toggleTheme()" id="theme-toggle" class="nav-theme-toggle" style="margin-left: 0;" title="Toggle light/dark theme">\uD83C\uDF19</button>';
+
+    html += '</div>';
+
+    nav.innerHTML = html;
+})();

--- a/js/script.js
+++ b/js/script.js
@@ -8505,6 +8505,8 @@ function showChangelog() {
                         <li><strong>Port Name Consistency:</strong> ARM parameter file adapter names now match the wizard's port display names (e.g., Port 1, Port 2) instead of generic NIC1/SMB1 prefixes.</li>
                         <li><strong>Configuration Summary Labels:</strong> The sidebar Configuration Summary now shows custom port names instead of generic "NIC X" labels.</li>
                         <li><strong>DNS Validation Gating:</strong> DNS server validation now blocks report and ARM generation instead of only showing a warning.</li>
+                        <li><strong>Shared Navigation Bar:</strong> Centralized nav bar into a shared <code>js/nav.js</code> component used by all pages, with a new 💡 Feedback link to GitHub Issues.</li>
+                        <li><strong>Sizer Disclaimer:</strong> Added development status notice on the Sizer page.</li>
                         <li><strong>CI Pipeline Hardening:</strong> ESLint, unit tests, and HTML validation CI jobs now block pull request merges on failure.</li>
                         <li><strong>198 Unit Tests:</strong> Expanded test suite from 136 to 198 tests with regression coverage for all bug fixes.</li>
                     </ul>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -17,40 +17,9 @@
     <link rel="stylesheet" href="sizer.css">
 </head>
 <body>
-    <!-- Tab Navigation -->
-    <nav class="odin-tab-nav">
-        <div class="odin-tab-container">
-            <a href="../index.html" class="odin-tab-logo">
-                <img src="../images/odin-logo.png" alt="Odin">
-                <span>ODIN</span>
-            </a>
-            <a href="../index.html" class="odin-tab-btn" data-tab="designer">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <rect x="3" y="3" width="18" height="18" rx="2"/>
-                    <path d="M3 9h18M9 21V9"/>
-                </svg>
-                Designer
-            </a>
-            <a href="../docs/outbound-connectivity/index.html" class="odin-tab-btn" data-tab="knowledge">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-                    <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
-                </svg>
-                Knowledge
-            </a>
-            <a href="#" class="odin-tab-btn active" data-tab="sizer">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M3 3v18h18"/>
-                    <path d="M18 17V9"/>
-                    <path d="M13 17V5"/>
-                    <path d="M8 17v-3"/>
-                </svg>
-                Sizer
-                <span class="odin-tab-badge">Preview</span>
-            </a>
-            <button onclick="toggleTheme()" id="theme-toggle" class="nav-theme-toggle" title="Toggle light/dark theme">ðŸŒ™</button>
-        </div>
-    </nav>
+    <!-- Tab Navigation (shared component) -->
+    <nav class="odin-tab-nav" id="odin-nav" data-active="sizer" data-base="../"></nav>
+    <script src="../js/nav.js"></script>
 
     <main class="container">
         <!-- Header -->
@@ -69,6 +38,12 @@
                 </button>
             </div>
         </header>
+
+        <div style="display: flex; justify-content: center; margin-bottom: 12px;">
+            <div style="font-size: 12px; color: var(--text-primary); padding: 12px; background: rgba(255, 193, 7, 0.15); border: 1px solid rgba(255, 193, 7, 0.4); border-radius: 8px;">
+                <strong>⚠️ Note:</strong> The Sizer functionality is in active development. Using the Sizer output as input for the Designer wizard will be available in a future release.
+            </div>
+        </div>
 
         <div class="sizer-layout">
             <!-- Left Panel: Workload Configuration -->


### PR DESCRIPTION
## Summary

Shared navigation bar component, feedback link, and sizer disclaimer.

### Changes

#### Shared Navigation Component (js/nav.js)
Extracted the duplicated nav bar HTML from all three pages into a single shared `js/nav.js` component. Each page now uses a lightweight placeholder:

```html
<nav class="odin-tab-nav" id="odin-nav" data-active="designer" data-base=""></nav>
<script src="js/nav.js"></script>
```

- `data-active` controls which tab is highlighted (designer, knowledge, sizer)
- `data-base` sets the relative path prefix to the repo root

Any future nav changes (new tabs, links, buttons) only need to be made in one file.

#### Feedback Link
Added a "Feedback" link with lightbulb emoji in the nav bar (before the theme toggle), pointing to https://github.com/Azure/odinforazurelocal/issues. Now appears consistently on all pages via the shared component.

#### Sizer Disclaimer
Added a disclaimer-style banner on the Sizer page: "The Sizer functionality is in active development. Using the Sizer output as input for the Designer wizard will be available in a future release."

#### Documentation
Updated CHANGELOG.md, README.md (Latest Release + Appendix A), and What's New dialog in script.js with entries for all three changes.

### Files Changed
- **js/nav.js** (new) - Shared navigation component
- **index.html** - Replaced inline nav with shared component
- **sizer/index.html** - Replaced inline nav + added disclaimer banner
- **docs/outbound-connectivity/index.html** - Replaced inline nav
- **CHANGELOG.md** - Added shared nav section under Improved
- **README.md** - Added entries in Latest Release and Appendix A
- **js/script.js** - Added entries in What's New dialog

Tests: 198 tests, all passing
