### PR TITLE
v0.14.55 - Fix Mermaid export for mermaid.live (#94)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.55] - 2026-02-11
+
+### Fixed
+
+#### Mermaid Export for mermaid.live (#94)
+
+- **Dual Copy Buttons**: The single "Copy Mermaid" button has been replaced with two separate buttons: "Copy for Markdown" (wraps diagram in ````mermaid` code fences for GitHub/wikis/docs) and "Copy for Mermaid.live" (copies raw Mermaid code that works directly in mermaid.live and other Mermaid renderers).
+- **Root Cause**: The exported Mermaid code was always wrapped in markdown code fences (`` ```mermaid ... ``` ``), which is correct for markdown files but causes mermaid.live to fail with `UnknownDiagramError` because it cannot parse the fence markers as diagram syntax.
+- **Both Main Tool & Report**: The fix applies to both the main configuration wizard's diagram export and the Configuration Report's host networking diagram export.
+
+---
+
 ## [0.14.54] - 2026-02-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.14.54 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.14.55 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,8 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.14.54 - Latest Release
+### 🎉 Version 0.14.55 - Latest Release
+- **Mermaid Export for mermaid.live ([#94](https://github.com/Azure/odinforazurelocal/issues/94))**: Fixed exported Mermaid code failing on mermaid.live by adding separate "Copy for Mermaid.live" button that copies raw diagram code without markdown fences
 - **NIC Mapping to Intent ([#88](https://github.com/Azure/odinforazurelocal/issues/88))**: Fixed adapter-to-intent assignment ignoring RDMA on Low Capacity scale — non-RDMA ports now correctly preferred for Management + Compute across all scales
 - **Safari Drag-and-Drop ([#88](https://github.com/Azure/odinforazurelocal/issues/88))**: Fixed adapter mapping "flip-flop" on Safari where click fired after drag, reversing the user's intended assignment
 - **Mobile-Responsive Navigation ([#87](https://github.com/Azure/odinforazurelocal/issues/87))**: Nav bar now collapses to icon-only on mobile portrait; onboarding "Next" button always reachable
@@ -325,8 +326,8 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.14.54  
-**Last Updated**: February 10th 2026  
+**Version**: 0.14.55  
+**Last Updated**: February 11th 2026  
 **Compatibility**: Azure Local 2506+
 
 ---
@@ -340,6 +341,9 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.14.x Series (February 2026)
+
+#### 0.14.55 - Mermaid Export Fix for mermaid.live
+- **Mermaid Export for mermaid.live (#94)**: Fixed exported Mermaid code failing on mermaid.live because it was wrapped in markdown code fences. Added separate "Copy for Mermaid.live" (raw) and "Copy for Markdown" (fenced) buttons in both the main tool and the Configuration Report.
 
 #### 0.14.54 - NIC Mapping Fix, Mobile Nav & Mermaid Export
 - **NIC Mapping to Intent (#88)**: Fixed adapter assignment ignoring RDMA on Low Capacity scale

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.14.54 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.14.55 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>
@@ -2175,11 +2175,14 @@
                     <h3>Configuration Summary</h3>
                     <div id="summary-content"></div>
                     <div id="summary-diagram-container" class="summary-diagram"></div>
-                    <div id="mermaid-export-buttons" style="display: flex; gap: 8px; margin-bottom: 12px;">
-                        <button onclick="copyMermaidDiagram()" style="flex: 1; padding: 8px 12px; background: rgba(139, 92, 246, 0.1); border: 1px solid rgba(139, 92, 246, 0.3); color: var(--accent-purple); border-radius: 8px; cursor: pointer; font-size: 12px; font-weight: 600; transition: all 0.2s;" title="Copy Mermaid diagram markup to clipboard">
-                            📋 Copy Mermaid
+                    <div id="mermaid-export-buttons" style="display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap;">
+                        <button onclick="copyMermaidForMarkdown()" style="flex: 1; min-width: 120px; padding: 8px 12px; background: rgba(139, 92, 246, 0.1); border: 1px solid rgba(139, 92, 246, 0.3); color: var(--accent-purple); border-radius: 8px; cursor: pointer; font-size: 12px; font-weight: 600; transition: all 0.2s;" title="Copy Mermaid diagram wrapped in markdown code fences (for GitHub, wikis, docs)">
+                            📋 Copy for Markdown
                         </button>
-                        <button onclick="downloadMermaidDiagram()" style="flex: 1; padding: 8px 12px; background: rgba(139, 92, 246, 0.1); border: 1px solid rgba(139, 92, 246, 0.3); color: var(--accent-purple); border-radius: 8px; cursor: pointer; font-size: 12px; font-weight: 600; transition: all 0.2s;" title="Download diagram as Markdown file with Mermaid code block">
+                        <button onclick="copyMermaidRaw()" style="flex: 1; min-width: 120px; padding: 8px 12px; background: rgba(34, 197, 94, 0.1); border: 1px solid rgba(34, 197, 94, 0.3); color: var(--accent-green, #22c55e); border-radius: 8px; cursor: pointer; font-size: 12px; font-weight: 600; transition: all 0.2s;" title="Copy raw Mermaid code for mermaid.live or other Mermaid renderers">
+                            📋 Copy for Mermaid.live
+                        </button>
+                        <button onclick="downloadMermaidDiagram()" style="flex: 1; min-width: 120px; padding: 8px 12px; background: rgba(139, 92, 246, 0.1); border: 1px solid rgba(139, 92, 246, 0.3); color: var(--accent-purple); border-radius: 8px; cursor: pointer; font-size: 12px; font-weight: 600; transition: all 0.2s;" title="Download diagram as Markdown file with Mermaid code block">
                             ⬇️ Download .md
                         </button>
                     </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 // Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.14.54';
+const WIZARD_VERSION = '0.14.55';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -6480,10 +6480,10 @@ function generateMermaidDiagram() {
 }
 
 /**
- * Copy the Mermaid diagram to the clipboard.
+ * Copy the Mermaid diagram wrapped in markdown code fences (for GitHub, wikis, docs).
  * Shows a notification on success or failure.
  */
-function copyMermaidDiagram() {
+function copyMermaidForMarkdown() {
     const mermaid = generateMermaidDiagram();
     if (!mermaid) {
         if (typeof showNotification === 'function') {
@@ -6497,7 +6497,7 @@ function copyMermaidDiagram() {
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(mermaidBlock).then(() => {
             if (typeof showNotification === 'function') {
-                showNotification('Mermaid diagram copied to clipboard!', 'success');
+                showNotification('Mermaid diagram copied to clipboard (Markdown format)!', 'success');
             }
         }).catch(() => {
             fallbackCopyMermaid(mermaidBlock);
@@ -6505,6 +6505,39 @@ function copyMermaidDiagram() {
     } else {
         fallbackCopyMermaid(mermaidBlock);
     }
+}
+
+/**
+ * Copy the raw Mermaid diagram to the clipboard (for mermaid.live and other renderers).
+ * Shows a notification on success or failure.
+ */
+function copyMermaidRaw() {
+    const mermaid = generateMermaidDiagram();
+    if (!mermaid) {
+        if (typeof showNotification === 'function') {
+            showNotification('Configure nodes, ports, and intent first to generate a diagram.', 'warning');
+        }
+        return;
+    }
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(mermaid).then(() => {
+            if (typeof showNotification === 'function') {
+                showNotification('Mermaid diagram copied to clipboard (raw format for mermaid.live)!', 'success');
+            }
+        }).catch(() => {
+            fallbackCopyMermaid(mermaid);
+        });
+    } else {
+        fallbackCopyMermaid(mermaid);
+    }
+}
+
+/**
+ * Legacy alias — calls copyMermaidForMarkdown for backward compatibility.
+ */
+function copyMermaidDiagram() {
+    copyMermaidForMarkdown();
 }
 
 /**
@@ -8932,7 +8965,19 @@ function showChangelog() {
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.54 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.55 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 11, 2026</div>
+                </div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🐛 Bug Fixes</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Mermaid Export for mermaid.live (<a href='https://github.com/Azure/odinforazurelocal/issues/94'>#94</a>):</strong> Fixed exported Mermaid code failing on mermaid.live because it was wrapped in markdown code fences. Added separate "Copy for Mermaid.live" button that copies raw diagram code.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.14.54</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">February 10, 2026</div>
                 </div>
 

--- a/report/report.js
+++ b/report/report.js
@@ -6,6 +6,7 @@
     window.downloadHostNetworkingDiagramSvg = downloadHostNetworkingDiagramSvg;
     window.downloadOutboundConnectivityDiagramSvg = downloadOutboundConnectivityDiagramSvg;
     window.copyHostNetworkingMermaid = copyHostNetworkingMermaid;
+    window.copyHostNetworkingMermaidRaw = copyHostNetworkingMermaidRaw;
     window.downloadHostNetworkingMermaid = downloadHostNetworkingMermaid;
     window.togglePrintFriendly = togglePrintFriendly;
 
@@ -1842,7 +1843,7 @@
     }
 
     /**
-     * Copy the host networking Mermaid diagram to clipboard.
+     * Copy the host networking Mermaid diagram to clipboard (markdown fenced format).
      */
     function copyHostNetworkingMermaid() {
         if (!CURRENT_REPORT_STATE) return;
@@ -1852,12 +1853,31 @@
         var block = '```mermaid\n' + mermaid + '\n```';
         if (navigator.clipboard && navigator.clipboard.writeText) {
             navigator.clipboard.writeText(block).then(function () {
-                alert('Mermaid diagram copied to clipboard!');
+                alert('Mermaid diagram copied to clipboard (Markdown format)!');
             }).catch(function () {
                 fallbackCopy(block);
             });
         } else {
             fallbackCopy(block);
+        }
+    }
+
+    /**
+     * Copy the host networking Mermaid diagram to clipboard (raw format for mermaid.live).
+     */
+    function copyHostNetworkingMermaidRaw() {
+        if (!CURRENT_REPORT_STATE) return;
+        var mermaid = generateHostNetworkingMermaid(CURRENT_REPORT_STATE);
+        if (!mermaid) return;
+
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(mermaid).then(function () {
+                alert('Mermaid diagram copied to clipboard (raw format for mermaid.live)!');
+            }).catch(function () {
+                fallbackCopy(mermaid);
+            });
+        } else {
+            fallbackCopy(mermaid);
         }
     }
 
@@ -6086,9 +6106,19 @@
                             var btnMermaidCopy = document.createElement('button');
                             btnMermaidCopy.type = 'button';
                             btnMermaidCopy.className = 'report-action-button';
-                            btnMermaidCopy.textContent = '📋 Copy Mermaid';
+                            btnMermaidCopy.textContent = '📋 Copy for Markdown';
+                            btnMermaidCopy.title = 'Copy Mermaid diagram wrapped in markdown code fences (for GitHub, wikis, docs)';
                             btnMermaidCopy.addEventListener('click', function () {
                                 window.copyHostNetworkingMermaid();
+                            });
+
+                            var btnMermaidCopyRaw = document.createElement('button');
+                            btnMermaidCopyRaw.type = 'button';
+                            btnMermaidCopyRaw.className = 'report-action-button';
+                            btnMermaidCopyRaw.textContent = '📋 Copy for Mermaid.live';
+                            btnMermaidCopyRaw.title = 'Copy raw Mermaid code for mermaid.live or other Mermaid renderers';
+                            btnMermaidCopyRaw.addEventListener('click', function () {
+                                window.copyHostNetworkingMermaidRaw();
                             });
 
                             var btnMermaidDl = document.createElement('button');
@@ -6100,6 +6130,7 @@
                             });
 
                             btnWrap.appendChild(btnMermaidCopy);
+                            btnWrap.appendChild(btnMermaidCopyRaw);
                             btnWrap.appendChild(btnMermaidDl);
                             hostSec.appendChild(btnWrap);
                         }


### PR DESCRIPTION
## Changes

### Bug Fix: Mermaid export format does not work when importing to mermaid.live (#94)

**Root Cause:** The exported Mermaid code was always wrapped in markdown code fences (\\\mermaid ... \\\), which is correct for markdown files but causes mermaid.live to fail with \UnknownDiagramError\ because it cannot parse the fence markers as diagram syntax.

**Fix:** Replaced the single 'Copy Mermaid' button with two separate buttons:
- **Copy for Markdown**  wraps diagram in code fences (for GitHub, wikis, docs)
- **Copy for Mermaid.live**  copies raw Mermaid code that works directly in mermaid.live

**Scope:** Both the main configuration wizard and the Configuration Report's host networking diagram export.

**Version bump:** 0.14.54  0.14.55

Closes #94