### PR TITLE
fix: remove mermaid export buttons from wizard sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -2175,14 +2175,6 @@
                     <h3>Configuration Summary</h3>
                     <div id="summary-content"></div>
                     <div id="summary-diagram-container" class="summary-diagram"></div>
-                    <div id="mermaid-export-buttons" style="display: flex; gap: 8px; margin-bottom: 12px;">
-                        <button onclick="copyMermaidDiagram()" style="flex: 1; padding: 8px 12px; background: rgba(139, 92, 246, 0.1); border: 1px solid rgba(139, 92, 246, 0.3); color: var(--accent-purple); border-radius: 8px; cursor: pointer; font-size: 12px; font-weight: 600; transition: all 0.2s;" title="Copy Mermaid diagram markup to clipboard">
-                            📋 Copy Mermaid
-                        </button>
-                        <button onclick="downloadMermaidDiagram()" style="flex: 1; padding: 8px 12px; background: rgba(139, 92, 246, 0.1); border: 1px solid rgba(139, 92, 246, 0.3); color: var(--accent-purple); border-radius: 8px; cursor: pointer; font-size: 12px; font-weight: 600; transition: all 0.2s;" title="Download diagram as Markdown file with Mermaid code block">
-                            ⬇️ Download .md
-                        </button>
-                    </div>
 
                     <button onclick="showTemplates()" style="width: 100%; padding: 10px 16px; background: rgba(59, 130, 246, 0.1); border: 1px solid rgba(59, 130, 246, 0.3); color: var(--accent-blue); border-radius: 8px; cursor: pointer; font-size: 13px; font-weight: 600; transition: all 0.2s; margin-bottom: 8px;">
                         📋 Load Example Configuration Template


### PR DESCRIPTION
Removes the 'Copy Mermaid' and 'Download .md' buttons from the wizard sidebar. These export buttons belong only on the Configuration Report page, where the dual format options (Copy for Markdown / Copy for Mermaid.live / Download .md) are already available.