### PR TITLE
v0.14.57 - Fix storage subnet CIDRs for Auto IP (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.57] - 2026-02-12
+
+### Fixed
+
+#### Storage Subnet CIDRs (#99)
+
+- **Network ATC Default Subnets**: SVG diagram legends now show the correct Network ATC default subnets (`10.71.x.0/24`) when Storage Auto IP is enabled. Previously displayed incorrect `10.0.x.0/24` addresses. The fix updates `getStorageSubnetCidr()` to return `10.71.{subnetIndex}.0/24` when Auto IP is active, consistent with the report HTML tables which already referenced the `10.71.0.0/16` range.
+
+---
+
 ## [0.14.56] - 2026-02-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.14.56 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.14.57 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,10 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.14.56 - Latest Release
+### 🎉 Version 0.14.57 - Latest Release
+- **Storage Subnet CIDRs ([#99](https://github.com/Azure/odinforazurelocal/issues/99))**: SVG diagram legends now show correct Network ATC default subnets (10.71.x.0/24) when Auto IP is enabled, instead of incorrect 10.0.x.0/24 addresses
+
+### Version 0.14.56
 - **draw.io Orthogonal Routing ([#94](https://github.com/Azure/odinforazurelocal/issues/94))**: Switchless storage subnet connectors now use L-shaped orthogonal routing (down → horizontal lane → up) instead of straight overlapping lines, matching the ODIN SVG diagram style
 - **Canonical Switchless Port Layout**: Switchless topologies now force canonical port allocation (2 management+compute + (n-1)×2 storage ports) regardless of user port count, ensuring correct mesh connectivity
 - **draw.io Export Scoped to Report**: Removed draw.io export button from the main wizard page; the download is now available exclusively on the Configuration Report page
@@ -322,8 +325,8 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.14.56  
-**Last Updated**: February 11th 2026  
+**Version**: 0.14.57  
+**Last Updated**: February 12th 2026  
 **Compatibility**: Azure Local 2506+
 
 ---
@@ -337,6 +340,9 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.14.x Series (February 2026)
+
+#### 0.14.57 - Storage Subnet CIDR Fix
+- **Storage Subnet CIDRs (#99)**: SVG diagram legends now show correct Network ATC default subnets (10.71.x.0/24) when Auto IP is enabled
 
 #### 0.14.56 - draw.io Orthogonal Routing & Report-Only Export
 - **draw.io Orthogonal Routing (#94)**: Switchless storage connectors use L-shaped routing with dedicated lanes per subnet

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.14.56 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.14.57 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 ﻿// Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.14.56';
+const WIZARD_VERSION = '0.14.57';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -8639,12 +8639,24 @@ function showChangelog() {
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.56 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.57 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 12, 2026</div>
+                </div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🐛 Bug Fixes</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Storage Subnet CIDRs (<a href='https://github.com/Azure/odinforazurelocal/issues/99'>#99</a>):</strong> SVG diagram legends now show correct Network ATC default subnets (10.71.x.0/24) when Auto IP is enabled, instead of incorrect 10.0.x.0/24 addresses.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.14.56</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">February 11, 2026</div>
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
-                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">� Improvements</h4>
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">✨ Improvements</h4>
                     <ul style="margin: 0; padding-left: 20px;">
                         <li><strong>draw.io Orthogonal Routing (<a href='https://github.com/Azure/odinforazurelocal/issues/94'>#94</a>):</strong> Switchless storage connectors now use L-shaped orthogonal routing with dedicated lanes per subnet instead of straight overlapping lines.</li>
                         <li><strong>Canonical Switchless Port Layout:</strong> Switchless topologies force canonical port allocation ensuring correct mesh connectivity for all node counts.</li>

--- a/report/report.js
+++ b/report/report.js
@@ -269,6 +269,10 @@
             var customCidr = String(state.customStorageSubnets[subnetIndex - 1]).trim();
             if (customCidr) return customCidr;
         }
+        // When Auto IP is enabled, use Network ATC default subnets (10.71.0.0/16 range)
+        if (state && state.storageAutoIp !== 'disabled') {
+            return '10.71.' + subnetIndex + '.0/24';
+        }
         return defaultCidr;
     }
 


### PR DESCRIPTION
## Changes

### Bug Fix - Storage Subnet CIDRs (#99)

When **Storage Auto IP** is enabled, the SVG diagram legends were showing incorrect subnet CIDRs (\10.0.x.0/24\) instead of the correct Network ATC default subnets (\10.71.x.0/24\).

**Root cause:** \getStorageSubnetCidr()\ in \eport/report.js\ returned the caller-provided default CIDR when Auto IP was active. All SVG diagram callers passed \10.0.x.0/24\ as defaults.

**Fix:** Added a check in \getStorageSubnetCidr()\  when Auto IP is enabled (\storageAutoIp !== 'disabled'\), the function now returns \10.71.{subnetIndex}.0/24\ (Network ATC default range). This single-point fix corrects all 4 topology diagrams (2-node, 3-node single/dual-link, 4-node).

### Files Changed
- \eport/report.js\ - Core fix in \getStorageSubnetCidr()\
- \js/script.js\ - Version bump + What's New entry
- \index.html\ - Version bump
- \README.md\ - Version bump + release notes
- \CHANGELOG.md\ - New changelog entry

Closes #99