### PR TITLE
v0.14.59 - Fix summary blade NIC mapping after custom adapter mapping (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.59] - 2026-02-12
+
+### Fixed
+
+#### Summary Blade NIC Mapping (#88)
+
+- **Custom Adapter Mapping in Summary**: The right-side summary blade now correctly displays the user's custom NIC-to-intent mapping after clicking "Confirm Adapter Mapping". Previously, `getNicMapping()` used hardcoded default logic (Port 1,2 → Mgmt+Compute, Port 3+ → Storage) regardless of the user's drag-and-drop rearrangement. Added a check at the top of `getNicMapping()` to read from `state.adapterMapping` when `state.adapterMappingConfirmed` is true, consistent with how `getIntentNicGroups()` already handles this for the OVERRIDES section.
+
+---
+
 ## [0.14.58] - 2026-02-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.14.58 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.14.59 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,10 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.14.58 - Latest Release
+### 🎉 Version 0.14.59 - Latest Release
+- **Summary Blade NIC Mapping ([#88](https://github.com/Azure/odinforazurelocal/issues/88))**: Summary blade now updates to reflect custom adapter mapping after confirming, instead of always showing default port assignments
+
+### Version 0.14.58
 - **Character Encoding Fix ([#103](https://github.com/Azure/odinforazurelocal/issues/103))**: Fixed 106 corrupted UTF-8 characters in Configuration Report diagrams (em dashes, arrows, emojis) that displayed as garbled text due to double-encoding
 
 ### Version 0.14.57
@@ -328,7 +331,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.14.58  
+**Version**: 0.14.59  
 **Last Updated**: February 12th 2026  
 **Compatibility**: Azure Local 2506+
 
@@ -343,6 +346,9 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.14.x Series (February 2026)
+
+#### 0.14.59 - Summary Blade NIC Mapping Fix
+- **Summary Blade NIC Mapping (#88)**: Summary blade now reflects custom adapter mapping after confirmation
 
 #### 0.14.58 - Character Encoding Fix
 - **Character Encoding (#103)**: Fixed 106 corrupted UTF-8 characters in Configuration Report diagrams and legends

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.14.58 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.14.59 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 ﻿// Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.14.58';
+const WIZARD_VERSION = '0.14.59';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -5665,6 +5665,25 @@ function getNicMapping(intent, portCount, isSwitchless) {
     const mapping = [];
     const pn = (i) => getPortDisplayName(i); // Use custom port names
 
+    // If adapter mapping is confirmed, use the user's custom assignments
+    if (state.adapterMappingConfirmed && state.adapterMapping && Object.keys(state.adapterMapping).length > 0) {
+        const trafficNames = {
+            'mgmt_compute': 'Management + Compute',
+            'storage': 'Storage',
+            'compute_storage': 'Compute + Storage',
+            'mgmt': 'Management',
+            'compute': 'Compute',
+            'all': 'All Traffic'
+        };
+        for (let i = 1; i <= portCount; i++) {
+            const assignment = state.adapterMapping[i];
+            if (assignment && assignment !== 'pool') {
+                mapping.push(`${pn(i)}: ${trafficNames[assignment] || assignment}`);
+            }
+        }
+        return mapping.length > 0 ? mapping.join('<br>') : null;
+    }
+
     if (intent === 'all_traffic') {
         for (let i = 1; i <= portCount; i++) {
             mapping.push(`${pn(i)}: Management + Compute + Storage`);
@@ -8639,7 +8658,19 @@ function showChangelog() {
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.58 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.59 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 12, 2026</div>
+                </div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🐛 Bug Fixes</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Summary Blade NIC Mapping (<a href='https://github.com/Azure/odinforazurelocal/issues/88'>#88</a>):</strong> The right-side summary blade now updates to reflect custom adapter mapping after confirming, instead of always showing the default port assignments.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.14.58</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">February 12, 2026</div>
                 </div>
 


### PR DESCRIPTION
## Changes

### Bug Fix - Summary Blade NIC Mapping (#88)

After dragging and dropping adapter ports to rearrange NIC mapping and clicking **Confirm Adapter Mapping**, the right-side summary blade did NOT update to reflect the custom mapping. It continued showing the default assignment (Port 1,2: Mgmt+Compute / Port 3,4: Storage) even though the OVERRIDES section correctly displayed the user's custom mapping.

**Root cause:** \getNicMapping()\ used hardcoded default logic to determine port-to-intent assignments. It never checked \state.adapterMappingConfirmed\ or \state.adapterMapping\.

**Fix:** Added a check at the top of \getNicMapping()\  when \state.adapterMappingConfirmed\ is true and \state.adapterMapping\ has entries, the function now builds the NIC Mapping display from the user's custom assignments instead of hardcoded defaults. This is the same pattern already used by \getIntentNicGroups()\ for the OVERRIDES section.

### Files Changed
- \js/script.js\ - Core fix in \getNicMapping()\, version bump, What's New entry
- \index.html\ - Version bump
- \README.md\ - Version bump + release notes
- \CHANGELOG.md\ - New changelog entry

Closes #88