### PR TITLE
fix: correct 2-node switchless legend note to reference Network ATC defaults

### DIFF
--- a/report/report.js
+++ b/report/report.js
@@ -4027,7 +4027,7 @@
                     2: getStorageSubnetCidr(state, 2, '10.0.2.0/24')
                 };
                 var legendTitle2 = hasCustomStorageSubnets(state) ? 'Storage subnets (custom)' : 'Storage subnets (conceptual)';
-                var legendNote2 = getStorageSubnetNote(state, "CIDRs shown are an extrapolated example consistent with Microsoft Learn's 4-node switchless storage intent numbering; use your own addressing plan.");
+                var legendNote2 = getStorageSubnetNote(state, "CIDRs shown are the default Network ATC values for 2-node switchless storage connectivity; these are automatically assigned.");
 
                 var legend2 = '<div class="switchless-diagram__legend">'
                     + '<div class="switchless-diagram__legend-title">' + legendTitle2 + '</div>'


### PR DESCRIPTION
The 2-node switchless diagram legend incorrectly stated CIDRs were 'consistent with Microsoft Learn''s 4-node switchless storage intent numbering'. For 2-node switchless, storage IPs are default Network ATC values that are automatically assigned  not user-provided or extrapolated from the 4-node pattern.

**Change:** Updated the legend note at report/report.js L4030 to read:
> CIDRs shown are the default Network ATC values for 2-node switchless storage connectivity; these are automatically assigned.

No version bump  no associated issue.