### PR TITLE
fix: 2-node switchless missing second VLAN ID and diagram port labels (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.60] - 2026-02-12
+
+### Fixed
+
+#### 2-Node Switchless Storage VLANs & Report Diagram (#93)
+
+- **Missing Second VLAN ID Field**: `getStorageVlanOverrideNetworkCount()` unconditionally returned `1` for all switchless scenarios. For 2-node switchless, which requires two storage networks (VLANs 711 and 712), the function now returns `2`. This fixes the overrides UI (only 1 VLAN field shown), ARM template output (only 1 StorageNetwork entry), and configuration summary (only 1 VLAN displayed).
+- **Report Diagram Port Labels**: The 2-node switchless Configuration Report diagram hardcoded port indices (Port 1,2 → Mgmt+Compute, Port 3,4 → Storage) instead of reading the user's custom adapter mapping from `state.adapterMapping`. Now resolves actual port assignments so the diagram matches the wizard configuration.
+
+---
+
 ## [0.14.59] - 2026-02-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.14.59 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.14.60 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,10 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.14.59 - Latest Release
+### 🎉 Version 0.14.60 - Latest Release
+- **2-Node Switchless VLAN & Diagram Fix ([#93](https://github.com/Azure/odinforazurelocal/issues/93))**: 2-node switchless now correctly shows two Storage VLAN ID fields (711, 712) in overrides, ARM output, and summary. Configuration Report diagram now reflects the user's custom adapter mapping instead of hardcoded port assignments.
+
+### Version 0.14.59
 - **Summary Blade NIC Mapping ([#88](https://github.com/Azure/odinforazurelocal/issues/88))**: Summary blade now updates to reflect custom adapter mapping after confirming, instead of always showing default port assignments
 
 ### Version 0.14.58
@@ -331,7 +334,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.14.59  
+**Version**: 0.14.60  
 **Last Updated**: February 12th 2026  
 **Compatibility**: Azure Local 2506+
 
@@ -346,6 +349,10 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.14.x Series (February 2026)
+
+#### 0.14.60 - 2-Node Switchless VLAN & Diagram Fix
+- **2-Node Switchless Storage VLANs (#93)**: `getStorageVlanOverrideNetworkCount()` now returns 2 for 2-node switchless, exposing both VLAN ID fields (711, 712) in overrides UI, ARM template, and summary
+- **Report Diagram Port Labels (#93)**: 2-node switchless diagram now reads actual port assignments from `state.adapterMapping` instead of hardcoding Port 1,2 → Mgmt+Compute and Port 3,4 → Storage
 
 #### 0.14.59 - Summary Blade NIC Mapping Fix
 - **Summary Blade NIC Mapping (#88)**: Summary blade now reflects custom adapter mapping after confirmation

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.14.59 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.14.60 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 ﻿// Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.14.59';
+const WIZARD_VERSION = '0.14.60';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -5417,8 +5417,13 @@ function updateCustomStorageSubnet(index, value) {
 function getStorageVlanOverrideNetworkCount() {
     // Step 05 Storage Connectivity controls how many storage networks exist.
     // - Switched: 2 storage networks
-    // - Switchless: 1 storage network
-    if (state.storage === 'switchless') return 1;
+    // - Switchless 2-node: 2 storage networks (VLANs 711, 712)
+    // - Switchless 3/4-node: 1 storage network (single VLAN across all subnets)
+    if (state.storage === 'switchless') {
+        var nodeCount = parseInt(state.nodes, 10) || 0;
+        if (nodeCount === 2) return 2;
+        return 1;
+    }
     if (state.storage === 'switched') {
         return 2;
     }
@@ -8658,7 +8663,20 @@ function showChangelog() {
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.59 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.60 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 12, 2026</div>
+                </div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🐛 Bug Fixes</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>2-Node Switchless Storage VLANs (<a href='https://github.com/Azure/odinforazurelocal/issues/93'>#93</a>):</strong> 2-node switchless now correctly shows two Storage VLAN ID fields (default 711, 712) in the overrides UI, ARM template output, and configuration summary. Previously only one VLAN field was shown.</li>
+                        <li><strong>Report Diagram Port Labels (<a href='https://github.com/Azure/odinforazurelocal/issues/93'>#93</a>):</strong> The 2-node switchless Configuration Report diagram now reflects the user's custom adapter mapping (e.g., Port 1,3 → Mgmt+Compute, Port 2,4 → Storage) instead of always showing Port 1,2 and Port 3,4.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.14.59</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">February 12, 2026</div>
                 </div>
 

--- a/report/report.js
+++ b/report/report.js
@@ -3892,6 +3892,19 @@
                     return getPortCustomName(state, idx1Based, 'nic');
                 }
 
+                // Resolve actual port assignments from adapter mapping or defaults
+                var mgmtComputePorts2 = [1, 2];
+                var storagePorts2 = [3, 4];
+                if (state.adapterMappingConfirmed && state.adapterMapping && Object.keys(state.adapterMapping).length > 0) {
+                    mgmtComputePorts2 = [];
+                    storagePorts2 = [];
+                    for (var ami = 1; ami <= portCount; ami++) {
+                        var amAssign = state.adapterMapping[ami] || 'pool';
+                        if (amAssign === 'storage') storagePorts2.push(ami);
+                        else mgmtComputePorts2.push(ami);
+                    }
+                }
+
                 function renderSetTeam2(nodeLeft, nodeTop) {
                     var setW = 220;
                     var setH = 62;
@@ -3919,8 +3932,8 @@
                         return t;
                     }
 
-                    out += nicTile(nic1X, nicY, getNicLabel2(1), 0);
-                    out += nicTile(nic2X, nicY, getNicLabel2(2), 1);
+                    out += nicTile(nic1X, nicY, getNicLabel2(mgmtComputePorts2[0] || 1), 0);
+                    out += nicTile(nic2X, nicY, getNicLabel2(mgmtComputePorts2[1] || 2), 1);
                     return out;
                 }
 
@@ -3995,8 +4008,8 @@
 
                     for (var p2 = 0; p2 < 2; p2++) {
                         var tr2 = storageTileRect2(i2, p2);
-                        // Storage ports start at port 3 (after 2 Mgmt+Compute ports)
-                        var lbl2 = getNicLabel2(p2 + 3);
+                        // Use actual storage port indices from adapter mapping
+                        var lbl2 = getNicLabel2(storagePorts2[p2] || (p2 + 3));
                         // Center text vertically if label is 11 characters or less, otherwise stagger
                         var textY2 = (lbl2.length <= 11) ? (tr2.y + 23) : ((p2 % 2 === 0) ? (tr2.y + 18) : (tr2.y + 28));
                         svg2 += '<rect x="' + tr2.x + '" y="' + tr2.y + '" width="' + tr2.w + '" height="' + tr2.h + '" rx="8" fill="rgba(139,92,246,0.25)" stroke="rgba(139,92,246,0.65)" />';


### PR DESCRIPTION
## Summary

Fixes two bugs in 2-node switchless scenario:

### Bug 1: Missing second Storage VLAN ID field
\getStorageVlanOverrideNetworkCount()\ unconditionally returned \1\ for all switchless scenarios. 2-node switchless requires **2 storage networks** (VLANs 711 and 712 from Network ATC defaults).

**Impact:** Only 1 VLAN field shown in overrides UI, only 1 StorageNetwork in ARM output, only 1 VLAN in summary.

**Fix:** Function now returns \2\ for 2-node switchless, \1\ for 3/4-node switchless.

### Bug 2: Report diagram shows wrong port assignments
The 2-node switchless Configuration Report diagram hardcoded port indices (Port 1,2  Mgmt+Compute, Port 3,4  Storage) instead of reading the user's custom adapter mapping.

**Fix:** Diagram now resolves actual port assignments from \state.adapterMapping\ when confirmed, falling back to defaults otherwise.

### Version bump
v0.14.59  v0.14.60

Closes #93