### PR TITLE
fix: correct variable name in 2-node switchless diagram adapter mapping loop (#93)

### DIFF
--- a/report/report.js
+++ b/report/report.js
@@ -3898,7 +3898,7 @@
                 if (state.adapterMappingConfirmed && state.adapterMapping && Object.keys(state.adapterMapping).length > 0) {
                     mgmtComputePorts2 = [];
                     storagePorts2 = [];
-                    for (var ami = 1; ami <= portCount; ami++) {
+                    for (var ami = 1; ami <= ports; ami++) {
                         var amAssign = state.adapterMapping[ami] || 'pool';
                         if (amAssign === 'storage') storagePorts2.push(ami);
                         else mgmtComputePorts2.push(ami);


### PR DESCRIPTION
Follow-up fix for PR #107. The adapter mapping resolution loop in the 2-node switchless report diagram used \portCount\ (undefined in this scope) instead of \ports\, causing the loop to never execute and the diagram to not render.

**One-line fix:** \portCount\  \ports\ at report/report.js L3902.

No version bump.