### PR TITLE
fix: 2-node switchless diagram port labels not reflecting adapter mapping (#93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.14.61] - 2026-02-12
+
+### Fixed
+
+#### 2-Node Switchless Diagram Port Labels (#93)
+
+- **Missing `ports` variable in `renderSwitchlessStorageDiagram()`**: The adapter mapping resolution loop used `ports` which was undefined in the `renderSwitchlessStorageDiagram` function scope (it existed in a different parent function). The loop condition `ami <= undefined` was always false, so the port arrays kept their hardcoded defaults `[1,2]` / `[3,4]` regardless of the user's custom mapping. Added `var ports = parseInt(state.ports, 10) || 0;` at the top of the function.
+
+---
+
 ## [0.14.60] - 2026-02-12
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.14.60 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.14.61 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,10 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.14.60 - Latest Release
+### 🎉 Version 0.14.61 - Latest Release
+- **2-Node Switchless Diagram Port Labels ([#93](https://github.com/Azure/odinforazurelocal/issues/93))**: Configuration Report diagram for 2-node switchless now correctly reflects the user's custom adapter mapping instead of always showing default Port 1,2 / Port 3,4 assignments
+
+### Version 0.14.60
 - **2-Node Switchless VLAN & Diagram Fix ([#93](https://github.com/Azure/odinforazurelocal/issues/93))**: 2-node switchless now correctly shows two Storage VLAN ID fields (711, 712) in overrides, ARM output, and summary. Configuration Report diagram now reflects the user's custom adapter mapping instead of hardcoded port assignments.
 
 ### Version 0.14.59
@@ -334,7 +337,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.14.60  
+**Version**: 0.14.61  
 **Last Updated**: February 12th 2026  
 **Compatibility**: Azure Local 2506+
 
@@ -349,6 +352,9 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.14.x Series (February 2026)
+
+#### 0.14.61 - 2-Node Switchless Diagram Port Labels Fix
+- **Report Diagram Port Labels (#93)**: Added missing `ports` variable in `renderSwitchlessStorageDiagram()` so adapter mapping resolution loop can iterate; diagram now shows correct port assignments
 
 #### 0.14.60 - 2-Node Switchless VLAN & Diagram Fix
 - **2-Node Switchless Storage VLANs (#93)**: `getStorageVlanOverrideNetworkCount()` now returns 2 for 2-node switchless, exposing both VLAN ID fields (711, 712) in overrides UI, ARM template, and summary

--- a/index.html
+++ b/index.html
@@ -365,7 +365,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.14.60 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.14.61 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 ﻿// Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.14.60';
+const WIZARD_VERSION = '0.14.61';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -8663,7 +8663,19 @@ function showChangelog() {
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.60 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.14.61 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 12, 2026</div>
+                </div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🐛 Bug Fixes</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>2-Node Switchless Diagram Port Labels (<a href='https://github.com/Azure/odinforazurelocal/issues/93'>#93</a>):</strong> The Configuration Report diagram for 2-node switchless now correctly reflects the user's custom adapter mapping (e.g., Port 1,3 → Storage, Port 2,4 → Mgmt+Compute) instead of always showing the default Port 1,2 / Port 3,4 split.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.14.60</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">February 12, 2026</div>
                 </div>
 

--- a/report/report.js
+++ b/report/report.js
@@ -3859,6 +3859,8 @@
                 return '<div style="color:var(--text-secondary);">Diagram is available for 2–4 node switchless scenarios only.</div>';
             }
 
+            var ports = parseInt(state.ports, 10) || 0;
+
             var REF_3NODE_SWITCHLESS = 'https://learn.microsoft.com/en-us/azure/azure-local/plan/three-node-switchless-two-switches-two-links?view=azloc-2511';
             var REF_3NODE_SWITCHLESS_SINGLE = 'https://learn.microsoft.com/en-us/azure/azure-local/plan/three-node-switchless-two-switches-one-link?view=azloc-2511';
 


### PR DESCRIPTION
## Summary

The 2-node switchless Configuration Report diagram always showed Port 1,2 in Mgmt+Compute and Port 3,4 in Storage regardless of the user's custom adapter mapping.

### Root Cause

The adapter mapping resolution loop (introduced in PR #107, fixed in PR #108 for wrong variable name) used \ports\  but this variable was **not defined** in the \enderSwitchlessStorageDiagram()\ function scope. It existed in a different parent function. Since \ports\ was \undefined\, the loop condition \mi <= undefined\ was always \alse\, so the port arrays kept their hardcoded defaults \[1,2]\ / \[3,4]\.

### Fix

Added \ar ports = parseInt(state.ports, 10) || 0;\ at the top of \enderSwitchlessStorageDiagram()\, right after the \
\ variable declaration. This makes \ports\ available throughout the function for the adapter mapping loop and any future use.

### Version bump
v0.14.60  v0.14.61

Closes #93