### PR TITLE
fix: Correct DCB System/Cluster Priority default from 5 to 7 (v0.15.96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.15.96] - 2026-02-16
+
+### Fixed
+
+#### DCB QoS System/Cluster Priority Default Correction ([#117](https://github.com/Azure/odinforazurelocal/issues/117))
+
+- **Corrected Default Cluster Priority**: Fixed the System/Cluster Priority dropdown in DCB QoS Overrides to show "Default (7)" instead of the incorrect "Default (5)". Per [Microsoft Network ATC documentation](https://learn.microsoft.com/en-us/windows-server/networking/network-atc/network-atc#default-data-center-bridging-dcb-configuration), the default Cluster Heartbeat priority is 7, not 5.
+- **Updated Historical CHANGELOG Entry**: Corrected the original DCB QoS feature entry (Issue #44) to reflect the correct default priority value.
+
+---
+
 ## [0.15.95] - 2026-02-15
 
 ### Changed
@@ -1461,7 +1472,7 @@ This ensures that when users import a previously exported ARM template, these im
 
 - **QoS Policy Customization** - Added new override options in the Network Traffic Intents section for storage intents that allow customization of Data Center Bridging (DCB) QoS policies:
   - **Storage Priority**: Choose between priority 3 (default) or 4 for SMB traffic
-  - **System/Cluster Priority**: Choose between priority 5 (default), 6, or 7 for cluster heartbeat traffic
+  - **System/Cluster Priority**: Choose between priority 7 (default), 5, or 6 for cluster heartbeat traffic
   - **Bandwidth Reservation**: Set the percentage of bandwidth reserved for storage traffic (40-70%, default 50%)
 
 - **ARM Template Support** - When QoS overrides are configured, the ARM template includes `overrideQosPolicy: true` and a `qosPolicyOverrides` object with the custom settings.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.15.95 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.15.96 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,7 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.15.95 - Latest Release
+### 🎉 Version 0.15.96 - Latest Release
 - **DIMM-Symmetric Memory Configuration (#119)**: Memory per Node is a dropdown with server-realistic DIMM-symmetric values (64, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096 GB) matching symmetric DIMM populations across 24 DIMM slots
 - **Expanded Disk Count Options (#119)**: Capacity Disks per Node and Cache Disks per Node dropdowns now include every value from 2–24 (capacity, all-flash) / 2–16 (capacity, hybrid) and 2–8 (cache), allowing any disk quantity
 - **Disk Size Auto-Scaling**: When disk count reaches 24 and storage is still insufficient, auto-scale steps up disk size through standard capacities (0.96, 1.92, 3.84, 7.68, 15.36 TB) with 80% headroom
@@ -340,7 +340,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.15.95  
+**Version**: 0.15.96  
 **Last Updated**: June 2026  
 **Compatibility**: Azure Local 2506+
 

--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.15.95 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.15.96 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 ﻿// Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.15.95';
+const WIZARD_VERSION = '0.15.96';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -5515,7 +5515,7 @@ function renderIntentOverrides(container) {
             <div class="config-row" style="margin-top:0.5rem;">
                 <span class="config-label">System/Cluster Priority</span>
                 <select class="speed-select" data-override-group="${g.key}" data-override-key="dcbSystemPriority">
-                    <option value="" ${!ov.dcbSystemPriority ? 'selected' : ''}>Default (5)</option>
+                    <option value="" ${!ov.dcbSystemPriority ? 'selected' : ''}>Default (7)</option>
                     <option value="5" ${ov.dcbSystemPriority === '5' ? 'selected' : ''}>5</option>
                     <option value="6" ${ov.dcbSystemPriority === '6' ? 'selected' : ''}>6</option>
                     <option value="7" ${ov.dcbSystemPriority === '7' ? 'selected' : ''}>7</option>
@@ -8759,7 +8759,19 @@ function showChangelog() {
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.15.95 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.15.96 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 16, 2026</div>
+                </div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🐛 DCB QoS System/Cluster Priority Default Correction (<a href='https://github.com/Azure/odinforazurelocal/issues/117'>#117</a>)</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Fixed Default Cluster Priority:</strong> Corrected the System/Cluster Priority dropdown default from "5" to "7" per <a href="https://learn.microsoft.com/en-us/windows-server/networking/network-atc/network-atc#default-data-center-bridging-dcb-configuration" target="_blank">Microsoft Network ATC documentation</a>.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.15.95</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">February 15, 2026</div>
                 </div>
 


### PR DESCRIPTION
## Summary

Fixes #117  The System/Cluster Priority default in the DCB QoS Overrides section was incorrectly labeled as **5** instead of **7**.

Per [Microsoft Network ATC documentation](https://learn.microsoft.com/en-us/windows-server/networking/network-atc/network-atc#default-data-center-bridging-dcb-configuration), the default DCB priorities are:

| Policy | Traffic Type | Priority |
|--------|-------------|----------|
| **Cluster** | Cluster Heartbeat | **7** |
| SMB_Direct | RDMA Storage Traffic | 3 |
| Default | All other traffic | 0 |

## Changes
- **js/script.js**: Changed the System/Cluster Priority dropdown default label from \Default (5)\ to \Default (7)\
- **js/script.js**: Updated What's New section with v0.15.96 entry
- **js/script.js**: Bumped \WIZARD_VERSION\ to \