### PR TITLE
fix: Default Gateway field unclickable on Safari (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.15.98] - 2026-02-16
+
+### Fixed
+
+#### Default Gateway Field Unclickable on Safari ([#98](https://github.com/Azure/odinforazurelocal/issues/98))
+
+- **Gateway Field Disable/Enable Consistency**: The Default Gateway input in Step 15 (Infrastructure Network) is now disabled with `opacity: 0.5` when no IP type is selected, matching the behaviour of the CIDR, Starting IP, and Ending IP fields. Previously the gateway was excluded from the `!state.ip` disable block, causing its parent `<div>` to have a different compositing state than its siblings. On Safari (macOS), this compositing mismatch could cause the browser to miscalculate hit-test regions, making the gateway field unclickable or untabbable. The DHCP/Static enable/disable logic later in `updateUI()` continues to manage the `disabled` property as before.
+
+---
+
 ## [0.15.97] - 2026-02-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.15.97 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.15.98 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,10 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.15.97 - Latest Release
+### 🎉 Version 0.15.98 - Latest Release
+- **Default Gateway Field Fix for Safari (#98)**: Fixed the Default Gateway input in Step 15 (Infrastructure Network) becoming unclickable on Safari. The field is now properly disabled/enabled alongside its sibling inputs, ensuring consistent compositing behaviour across all browsers.
+
+### Version 0.15.97
 - **Dynamic Storage Networks for Switched Storage (#113)**: Switched storage configurations with more than 2 RDMA NICs now dynamically generate the correct number of storage networks, VLANs, and ARM storageNetworkList entries (up to 8 per Network ATC). Previously hardcoded to 2 networks regardless of NIC count.
 
 ### Version 0.15.96
@@ -343,7 +346,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.15.97  
+**Version**: 0.15.98  
 **Last Updated**: June 2026  
 **Compatibility**: Azure Local 2506+
 

--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.15.97 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.15.98 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 ﻿// Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.15.97';
+const WIZARD_VERSION = '0.15.98';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 
@@ -4063,6 +4063,13 @@ function updateUI() {
             infraInputEnd.disabled = true;
             infraInputStart.parentElement.style.opacity = '0.5';
             infraInputEnd.parentElement.style.opacity = '0.5';
+            // Disable Default Gateway when no IP type is selected (#98).
+            // Keeps compositing/opacity consistent with sibling inputs,
+            // preventing Safari hit-testing quirks on the gateway field.
+            if (infraInputGateway) {
+                infraInputGateway.disabled = true;
+                infraInputGateway.parentElement.style.opacity = '0.5';
+            }
         } else {
             if (infraInputCidr) {
                 infraInputCidr.disabled = false;
@@ -4072,6 +4079,11 @@ function updateUI() {
             infraInputEnd.disabled = false;
             infraInputStart.parentElement.style.opacity = '1';
             infraInputEnd.parentElement.style.opacity = '1';
+            // Restore Default Gateway parent opacity; the DHCP/Static
+            // enable/disable logic later in updateUI() controls .disabled.
+            if (infraInputGateway) {
+                infraInputGateway.parentElement.style.opacity = '1';
+            }
         }
 
         // Restore input values from state (for Resume/Import functionality)
@@ -8744,7 +8756,19 @@ function showChangelog() {
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.15.97 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.15.98 - Latest Release</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">February 16, 2026</div>
+                </div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🐛 Default Gateway Field Fix for Safari (<a href='https://github.com/Azure/odinforazurelocal/issues/98'>#98</a>)</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Gateway Field Consistency:</strong> Default Gateway is now disabled with opacity when no IP type is selected, matching sibling inputs. Fixes an issue on Safari (macOS) where the field could become unclickable due to inconsistent compositing states.</li>
+                    </ul>
+                </div>
+
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.15.97</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">February 16, 2026</div>
                 </div>
 


### PR DESCRIPTION
## Summary

Resolves #98  Default Gateway input in Step 15 (Infrastructure Network) could become unclickable/untabbable on macOS Safari.

## Root Cause

The \updateUI()\ function disabled CIDR, Starting IP, and Ending IP fields (\disabled=true\ + \parentElement.style.opacity='0.5'\) when no IP type was selected (\!state.ip\), but **excluded the Default Gateway** from that block. This caused the gateway's parent \<div>\ to have a different compositing state than its siblings.

Safari (macOS) creates implicit compositing layers when inline opacity is set on elements. When adjacent sibling containers have mismatched compositing states, Safari can miscalculate hit-test regions, causing clicks on the non-composited sibling (the gateway) to be swallowed or misrouted.

## Fix

Include the Default Gateway in the \!state.ip\ disable block:
- When \!state.ip\: set \infraInputGateway.disabled = true\ and \parentElement.style.opacity = '0.5'\
- When \state.ip\ is set: restore \parentElement.style.opacity = '1'\ (the DHCP/Static logic later in \updateUI()\ manages \.disabled\)

This is also better UX  the gateway field shouldn't be editable before the user chooses Static vs DHCP.

## Version
0.15.97  0.15.98