### PR TITLE
Sizer: Rename Number of Nodes, add AUTO badge, fix disk count minimum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,8 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Sizer: AMD EPYC Turin Core Options
 - **Expanded Core Options**: Updated AMD 5th Gen EPYC Turin to include 144, 160, and 192 cores per socket (maxCores: 192), reflecting the full Turin product line. Previously capped at 128.
 
-#### Sizer: Cluster Type & Number of Nodes Label Styling
-- **Bolder Labels**: The "Cluster Type" and "Number of Nodes" labels now use a bolder weight (600), slightly larger font (15px), and the primary text colour, making them stand out from other configuration options.
+#### Sizer: Cluster Type & Number of Physical Nodes Label Styling
+- **Bolder Labels**: The "Cluster Type" and "Number of Physical Nodes" labels now use a bolder weight (600), slightly larger font (15px), and the primary text colour, making them stand out from other configuration options.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Sizer: Dead Code Cleanup**: Removed unused dual parity option, dead functions, and consolidated resiliency constants
 - **Sizer: Power Estimate Core Scaling**: CPU TDP in the power estimate now scales with the selected core count (40% base + 60% proportional), so reducing cores visibly reduces estimated power
 - **Sizer: Single Node Default Resiliency**: Single-node clusters now default to Two-Way Mirror instead of Simple (No Fault Tolerance)
-- **Sizer: Cluster Type & Nodes Label Styling**: The "Cluster Type" and "Number of Nodes" labels now use bolder weight, larger font, and primary text colour for better visibility
+- **Sizer: Cluster Type & Nodes Label Styling**: The "Cluster Type" and "Number of Physical Nodes" labels now use bolder weight, larger font, and primary text colour for better visibility
 - **Sizer: Disk Consolidation Count Fix**: Fixed disk bay consolidation only increasing disk count, never decreasing — consolidation now writes both count and size together, and stale counts no longer persist after page refresh/resume
 - **Sizer: Consolidation Note After Headroom**: Fixed the consolidation sizing note showing the wrong disk count when the storage headroom pass added extra disks after consolidation
 - **Sizer: HTML Validation Fix**: Encoded raw `&` as `&amp;` in the sizer heading to resolve HTML validation errors
@@ -378,7 +378,7 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 - **Sizer: Dead Code Cleanup**: Removed unused dual parity option, dead functions, and consolidated resiliency constants
 - **Sizer: Power Estimate Core Scaling**: CPU TDP in the power estimate now scales with the selected core count (40% base + 60% proportional), so reducing cores visibly reduces estimated power
 - **Sizer: Single Node Default Resiliency**: Single-node clusters now default to Two-Way Mirror instead of Simple (No Fault Tolerance)
-- **Sizer: Cluster Type & Nodes Label Styling**: Bolder weight, larger font, and primary text colour for Cluster Type and Number of Nodes labels
+- **Sizer: Cluster Type & Nodes Label Styling**: Bolder weight, larger font, and primary text colour for Cluster Type and Number of Physical Nodes labels
 - **Sizer: Disk Consolidation Count Fix**: Fixed consolidation only increasing disk count — now bidirectional; stale counts no longer persist after page refresh/resume
 - **Sizer: Consolidation Note After Headroom**: Fixed consolidation sizing note showing wrong disk count when headroom pass added extra disks
 - **Sizer: HTML Validation Fix**: Encoded raw `&` as `&amp;` in the sizer heading

--- a/js/script.js
+++ b/js/script.js
@@ -8782,7 +8782,7 @@ function showChangelog() {
                         <li><strong>Power Estimate Core Scaling:</strong> CPU TDP now scales with selected core count (40% base + 60% proportional), so reducing cores visibly reduces estimated power.</li>
                         <li><strong>Single Node Default Resiliency:</strong> Single-node clusters now default to Two-Way Mirror instead of Simple (No Fault Tolerance).</li>
                         <li><strong>Sizing Notes Consistency:</strong> Fixed edit-vs-add inconsistencies in vCPU ratio warnings and memory calculations.</li>
-                        <li><strong>Cluster Type &amp; Nodes Label Styling:</strong> Bolder weight, larger font, and primary text colour for the Cluster Type and Number of Nodes labels.</li>
+                        <li><strong>Cluster Type &amp; Nodes Label Styling:</strong> Bolder weight, larger font, and primary text colour for the Cluster Type and Number of Physical Nodes labels.</li>
                         <li><strong>Disk Consolidation Count Fix:</strong> Fixed consolidation only increasing disk count — now bidirectional; stale counts no longer persist after page refresh/resume.</li>
                         <li><strong>Consolidation Note After Headroom:</strong> Fixed consolidation sizing note showing the wrong disk count when the storage headroom pass added extra disks.</li>
                         <li><strong>HTML Validation Fix:</strong> Encoded raw &amp; as &amp;amp; in the sizer heading to resolve validation errors.</li>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -120,7 +120,7 @@
                         </select>
                     </div>
                     <div class="config-row cluster-setting">
-                        <label for="node-count">Number of Nodes</label>
+                        <label for="node-count">Number of Physical Nodes</label>
                         <select id="node-count" onchange="onNodeCountChange()">
                             <option value="2">2 Nodes</option>
                             <option value="3" selected>3 Nodes</option>

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -537,6 +537,9 @@ function updateNodeRecommendation(recommendation) {
         nodeSelect.value = snapped;
     }
 
+    // Mark the node-count field as auto-scaled (purple glow + AUTO badge)
+    markAutoScaled('node-count');
+
     // Update dependent UI (without triggering calculateRequirements)
     updateResiliencyOptions();
     updateClusterInfo();
@@ -578,7 +581,8 @@ const MAX_MEMORY_GB = 4096;
 const MIN_MEMORY_GB = 64;
 const MEMORY_OPTIONS_GB = [64, 128, 192, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096];
 
-// Max disk count per node
+// Disk count per node
+const MIN_DISK_COUNT = 2; // Azure Local minimum; matches dropdown minimum
 const MAX_DISK_COUNT = 24;
 const MAX_CACHE_DISK_COUNT = 8;
 const MAX_TIERED_CAPACITY_DISK_COUNT = 16; // 2U chassis: 8 cache + 16 capacity = 24 total (hybrid & mixed-flash)
@@ -766,9 +770,9 @@ function autoScaleHardware(totalVcpus, totalMemoryGB, totalStorageGB, nodeCount,
         const diskCountInput = document.getElementById(diskCountId);
         const currentDiskCount = parseInt(diskCountInput.value) || 4;
 
-        // Set disk count to the required amount, capped at max for storage type
+        // Set disk count to the required amount, clamped between min (2) and max for storage type
         const maxDisksForType = isTieredCapped ? MAX_TIERED_CAPACITY_DISK_COUNT : MAX_DISK_COUNT;
-        let targetDisks = Math.min(disksNeeded, maxDisksForType);
+        let targetDisks = Math.max(MIN_DISK_COUNT, Math.min(disksNeeded, maxDisksForType));
 
         // --- Disk bay consolidation ---
         // When the required disk count reaches ≥50% of max bays, check if fewer


### PR DESCRIPTION
## Changes

### Rename 'Number of Nodes' to 'Number of Physical Nodes'
- Updated the sizer label from **Number of Nodes** to **Number of Physical Nodes** for clarity
- Updated all text references in README, CHANGELOG, and the What's New section in script.js

### Add AUTO badge to Number of Physical Nodes
- The node-count dropdown now shows the purple glow animation and **AUTO** badge when the node count is auto-configured by the sizing engine
- Badge is automatically cleared when the user manually changes the dropdown

### Fix: Disk count auto-scale below dropdown minimum
- **Bug**: When auto-scaling computed a disk count of 1 (e.g., 10 default VMs on a single node), the dropdown had no matching option (minimum is 2), leaving the select visually blank while still showing the AUTO badge
- **Fix**: Added `MIN_DISK_COUNT = 2` constant and clamped `targetDisks` with `Math.max(MIN_DISK_COUNT, ...)` so the computed value never drops below the dropdown minimum

### Files changed
- `sizer/index.html` — Label rename
- `sizer/sizer.js` — AUTO badge for node-count, MIN_DISK_COUNT clamp
- `README.md` / `CHANGELOG.md` / `js/script.js` — Text reference updates