### PR TITLE
v0.16.01: Fix Sizer AUTO badge persistence across calculation cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Sizer: HTML Validation Fix
 - **Encoded Ampersand**: Fixed a raw `&` character in the "Estimated Power & Rack Space" heading in `sizer/index.html` to `&amp;`, resolving an HTML validation error.
 
+#### Sizer: AUTO Badge Persistence
+- **Re-apply AUTO Badges Across Cycles**: Fixed AUTO badges (purple glow + "AUTO" label) disappearing from the CPU Cores per Socket and Memory per Node fields when adding workloads that increase the node count without changing per-node hardware values. The `autoScaleHardware()` function only marked fields when increasing their value; if the value was already adequate from a prior auto-scale cycle, the badge was cleared but never re-applied. The fix saves previously auto-scaled field IDs before clearing highlights, and re-applies badges to fields whose values remain at their auto-scaled level.
+
 ### Removed
 
 #### Sizer: Dead Code Cleanup

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Sizer: Disk Consolidation Count Fix**: Fixed disk bay consolidation only increasing disk count, never decreasing — consolidation now writes both count and size together, and stale counts no longer persist after page refresh/resume
 - **Sizer: Consolidation Note After Headroom**: Fixed the consolidation sizing note showing the wrong disk count when the storage headroom pass added extra disks after consolidation
 - **Sizer: HTML Validation Fix**: Encoded raw `&` as `&amp;` in the sizer heading to resolve HTML validation errors
+- **Sizer: AUTO Badge Persistence Fix**: Fixed AUTO badges disappearing from CPU Cores per Socket and Memory per Node fields when adding workloads that increase node count without changing per-node hardware values
 
 > **Full Version History**: See [Appendix A - Version History](#appendix-a---version-history) for complete release notes.
 
@@ -382,6 +383,7 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 - **Sizer: Disk Consolidation Count Fix**: Fixed consolidation only increasing disk count — now bidirectional; stale counts no longer persist after page refresh/resume
 - **Sizer: Consolidation Note After Headroom**: Fixed consolidation sizing note showing wrong disk count when headroom pass added extra disks
 - **Sizer: HTML Validation Fix**: Encoded raw `&` as `&amp;` in the sizer heading
+- **Sizer: AUTO Badge Persistence Fix**: Fixed AUTO badges disappearing from CPU Cores and Memory fields when adding workloads that scale nodes without changing per-node values
 
 ### 🎉 Version 0.15.x Series (February 2026)
 

--- a/js/script.js
+++ b/js/script.js
@@ -8786,6 +8786,7 @@ function showChangelog() {
                         <li><strong>Disk Consolidation Count Fix:</strong> Fixed consolidation only increasing disk count — now bidirectional; stale counts no longer persist after page refresh/resume.</li>
                         <li><strong>Consolidation Note After Headroom:</strong> Fixed consolidation sizing note showing the wrong disk count when the storage headroom pass added extra disks.</li>
                         <li><strong>HTML Validation Fix:</strong> Encoded raw &amp; as &amp;amp; in the sizer heading to resolve validation errors.</li>
+                        <li><strong>AUTO Badge Persistence Fix:</strong> Fixed AUTO badges disappearing from CPU Cores per Socket and Memory per Node when adding workloads that scale nodes without changing per-node hardware values.</li>
                     </ul>
                 </div>
 


### PR DESCRIPTION
## Summary

Fixes AUTO badges (purple glow + **AUTO** label) disappearing from **CPU Cores per Socket** and **Memory per Node** fields when adding workloads that increase the node count without changing per-node hardware values.

## Problem

When adding 100x AKS clusters (default options), the sizer auto-scales CPU cores, memory, and disk count, correctly showing AUTO badges. When then adding 100x Azure Local VMs, the node count scales from 9 to 10, but the AUTO badges on CPU Cores per Socket and Memory per Node disappear — even though those values were set by auto-scale and remain adequate.

## Root Cause

- `clearAutoScaledHighlights()` removes all AUTO markers at the start of every `calculateRequirements()` cycle
- `autoScaleHardware()` only calls `markAutoScaled()` when it **increases** a value (e.g. `targetCores > currentCores`)
- With more nodes, per-node requirements decrease, so `targetCores <= currentCores` and `targetMem <= currentMem` — values don't change and badges are never re-applied
- `node-count` keeps its badge because `updateNodeRecommendation()` unconditionally calls `markAutoScaled('node-count')`

## Fix

1. Save previously auto-scaled field IDs (`new Set(_autoScaledFields)`) before clearing highlights
2. Pass `previouslyAutoScaled` to `autoScaleHardware()`
3. Re-apply AUTO badges for `cpu-cores` and `node-memory` when values remain at their auto-scaled level

Manual override behaviour is preserved: the `clearHandler` event listener removes fields from `_autoScaledFields` on user interaction, so they won't appear in `previouslyAutoScaled` on the next cycle.

## Files Changed

- **sizer/sizer.js** — Core fix
- **README.md** — Bug fix entry in What's New and Version History
- **CHANGELOG.md** — Detailed changelog entry
- **js/script.js** — What's New dialog entry