### PR TITLE
fix: Custom intent 8-port compute intent - separate Compute 1/Compute 2 zones (#130)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.16.02] - 2026-02-19
+
+### Fixed
+
+#### Custom Intent 8-Port Compute Intent Fix ([#130](https://github.com/Azure/odinforazurelocal/issues/130))
+
+- **Separate Compute Zones for 8-Port Custom Intent**: When using custom intent with 8 ports, the wizard now offers two distinct compute zones (`Compute 1` and `Compute 2`) instead of a single `Compute` zone. Previously, all ports assigned to compute merged into one intent group, making it impossible to create two separate compute intents as required for 8-port configurations.
+- **Expected 8-Port Layout**: 1 Management + Compute intent (mandatory), 2 independent Compute intents (optional), and 1 Storage intent (mandatory).
+- **ARM Template Alignment**: The ARM template output now generates separate intent entries for each compute zone (`Compute` and `Compute_2`) with `trafficType: ['Compute']`, matching Azure Local Network ATC requirements.
+- **Report Diagram Alignment**: The Configuration Report SVG diagram and Draw.io export correctly render separate compute intent groups with distinct labels and green color coding.
+- **Affected Files**: `js/script.js` (zone definitions, grouping logic, traffic type mapping, NIC mapping display, ARM intent naming), `report/report.js` (custom intent groups, adapter mapping groups, diagram coloring, draw.io export).
+
+---
+
 ## [0.16.01] - 2026-02-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.16.01 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.16.02 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) network architecture. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts.
 
@@ -37,7 +37,10 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.16.01 - Latest Release
+### 🎉 Version 0.16.02 - Latest Release
+- **Custom Intent 8-Port Compute Intent Fix (#130)**: With 8 ports and custom intent, the wizard now offers two distinct compute zones (Compute 1 and Compute 2) instead of merging all compute ports into a single intent group. The Configuration Report diagram and ARM template correctly reflect the separate compute intents.
+
+### Version 0.16.01
 - **Sizer: Standardised Disk Size Dropdown**: All disk size inputs replaced with dropdown selects using standard NVMe/SSD capacities (0.96, 1.92, 3.84, 7.68, 15.36 TB), eliminating invalid free-text entries
 - **Sizer: Delete Confirmation Dialog**: Deleting a workload now requires confirmation, preventing accidental removal
 - **Sizer: Clone Workload**: New clone button on each workload card to duplicate a workload with all its settings
@@ -343,7 +346,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.16.01  
+**Version**: 0.16.02  
 **Last Updated**: February 2026  
 **Compatibility**: Azure Local 2506+
 

--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.16.01 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.16.02 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/report/report.js
+++ b/report/report.js
@@ -1638,7 +1638,7 @@
             if (hasAdapterMapping && s.adapterMapping[nic]) {
                 var m = s.adapterMapping[nic];
                 if (m === 'mgmt') return ['m', 'c'];
-                if (m === 'compute') return ['c'];
+                if (m === 'compute' || m === 'compute_1' || m === 'compute_2') return ['c'];
                 if (m === 'storage') return ['s'];
                 if (m === 'mgmt_compute') return ['m', 'c'];
                 if (m === 'compute_storage') return ['c', 's'];
@@ -1657,7 +1657,7 @@
             if (intent === 'custom') {
                 var val = (s.customIntents && s.customIntents[nic]) || 'unused';
                 if (val === 'mgmt') return ['m'];
-                if (val === 'compute') return ['c'];
+                if (val === 'compute' || val === 'compute_1' || val === 'compute_2') return ['c'];
                 if (val === 'storage') return ['s'];
                 if (val === 'mgmt_compute') return ['m', 'c'];
                 if (val === 'compute_storage') return ['c', 's'];
@@ -2478,6 +2478,8 @@
                 var trafficNames = {
                     mgmt: 'Management',
                     compute: 'Compute',
+                    compute_1: 'Compute 1',
+                    compute_2: 'Compute 2',
                     storage: 'Storage',
                     mgmt_compute: 'Management + Compute',
                     compute_storage: 'Compute + Storage',
@@ -2495,7 +2497,7 @@
                 }
 
                 // Always show Mgmt + Compute first when present.
-                var order = ['mgmt_compute', 'mgmt', 'compute', 'compute_storage', 'storage', 'all'];
+                var order = ['mgmt_compute', 'mgmt', 'compute', 'compute_1', 'compute_2', 'compute_storage', 'storage', 'all'];
                 var groups = [];
                 for (var oi = 0; oi < order.length; oi++) {
                     var key = order[oi];
@@ -2524,6 +2526,9 @@
 
                 var trafficNames = {
                     mgmt: 'Management + Compute',
+                    compute: 'Compute',
+                    compute_1: 'Compute 1',
+                    compute_2: 'Compute 2',
                     storage: 'Storage',
                     compute_storage: 'Compute + Storage',
                     all: 'All Traffic',
@@ -2539,7 +2544,7 @@
                     buckets[assignment].push(i);
                 }
 
-                var order = ['mgmt', 'storage', 'compute_storage', 'all'];
+                var order = ['mgmt', 'compute', 'compute_1', 'compute_2', 'storage', 'compute_storage', 'all'];
                 var groups = [];
                 for (var oi = 0; oi < order.length; oi++) {
                     var key = order[oi];
@@ -2823,7 +2828,7 @@
                     
                     // Color based on intent type
                     var isStorageLike = grp.isStorageLike;
-                    var isCompute = (grp.key === 'compute');
+                    var isCompute = (grp.key === 'compute' || grp.key === 'compute_1' || grp.key === 'compute_2');
                     var boxFill, boxStroke;
                     if (isStorageLike) {
                         boxFill = 'rgba(139,92,246,0.07)';


### PR DESCRIPTION
## Summary

Fixes #130 - Second compute intent is shown as Management + Compute when the user selects custom intent with 8 ports.

## Changes

### Root Cause
The custom intent system used a simple port-to-zone mapping where all ports assigned to the same zone type merged into a single intent group. This made it impossible to create two separate Compute intents, which is required for 8-port custom intent configurations.

### Fix
- **Zone Definitions** (\js/script.js\): When custom intent is selected with 8+ ports, the wizard now offers \Compute 1\ and \Compute 2\ as distinct zones instead of a single \Compute\ zone. For <8 ports, the single \Compute\ zone is preserved.
- **Grouping Logic**: Updated \getIntentNicGroups()\ traffic names and display order to include \compute_1\ and \compute_2\.
- **ARM Template**: \	rafficTypeForGroupBaseKey()\ maps both \compute_1\ and \compute_2\ to \['Compute']\. The ARM intent naming generates separate entries (\Compute\ and \Compute_2\).
- **NIC Mapping Display**: Both \getNicMapping()\ and \getCustomNicMapping()\ now display \Compute 1\ and \Compute 2\ labels.
- **Report Diagram** (\eport/report.js\): Updated \getCustomIntentGroups()\, \getAdapterMappingGroups()\, \getTraffic()\, and diagram coloring to handle the new compute zone keys.

### Version Bump
0.16.01  0.16.02

## Files Changed
- \js/script.js\ - Zone definitions, grouping, traffic mapping, NIC display, ARM naming, What's New
- \eport/report.js\ - Custom groups, adapter groups, traffic classification, diagram colors
- \index.html\ - Version header
- \README.md\ - Version and release notes
- \CHANGELOG.md\ - New entry