### PR TITLE
v0.16.04: Sizer mobile layout consistency and default 2-node cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sizer: Power units expanded to "Watts"**: Power values now display as "Watts" instead of "W" for improved readability
 - **Sizer: BTU Wikipedia link**: "BTU" in the Total BTU/hr label is now a hyperlink to the Wikipedia article for readers unfamiliar with the unit
 - **Sizer: Mobile header logo & What's New**: The ODIN logo and version/What's New text are now visible on mobile devices, centered alongside the header text with appropriate sizing
+- **Sizer: Mobile layout consistency**: On mobile devices, the Sizer header now matches the Designer page — the ODIN logo and What's New link appear centered at the top with the title and subtitle text immediately below, instead of side-by-side
+
+#### Sizer Defaults
+
+- **Sizer: Default cluster changed to Standard 2 Node**: The default cluster configuration is now a Standard 2 Node cluster (previously 3 Nodes), reducing the default starting hardware cost for sizing scenarios
+- **Sizer: Default resiliency changed to Two-Way Mirror**: The default storage resiliency is now Two-Way Mirror (previously Three-Way Mirror), consistent with the 2-node minimum. Three-Way Mirror remains available and is automatically selected when 3+ nodes are configured
 
 #### Security Meta Tag Cleanup
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Designer: Mobile stats bar 2×2 layout**: Page analytics bar displays as a 2×2 grid on mobile devices
 - **Sizer: "Estimated Power, Heat & Rack Space"**: Updated heading to include "Heat" since BTU/hr values are shown; power units expanded from "W" to "Watts"; BTU is now a Wikipedia hyperlink
 - **Sizer: Mobile header logo**: ODIN logo and What's New text now visible on mobile devices
+- **Sizer: Mobile layout consistency**: On mobile, the Sizer header now matches the Designer page — logo and What's New centered at top, title and subtitle below
+- **Sizer: Default 2 Node cluster**: Default cluster changed from 3 Node / Three-Way Mirror to 2 Node / Two-Way Mirror, reducing the default starting hardware cost
 - **Security: Removed invalid meta tags**: Removed `X-Frame-Options` and `X-XSS-Protection` meta tags (HTTP-header-only directives, ineffective in `<meta>` tags)
 - **Sizer: Bug Fixes**: vCPU ratio AUTO badge, label correction, node recommendation memory cap, stale recommendation, manual hardware override, node count reset, 1.5 TB memory threshold, memory headroom, bidirectional auto-scaling, sizing notes reorder
 - **Sizer: Workload Analytics Tracking**: Each new workload added in the Sizer (VM, AKS, or AVD) is now tracked via tracking analytics, to display the "Sizes Calculated" on the main page stats bar
@@ -361,6 +363,8 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 - **Designer: Mobile stats bar 2×2 layout**: Page analytics bar on the Designer home page now displays as a 2×2 grid on mobile devices instead of a single row of 4 items
 - **Sizer: "Estimated Power, Heat & Rack Space"**: Updated heading to include "Heat" since the section displays BTU/hr values; power units expanded from "W" to "Watts"; BTU is now a Wikipedia hyperlink
 - **Sizer: Mobile header logo & What's New**: ODIN logo and version/What's New text now visible on mobile devices, centered alongside header text
+- **Sizer: Mobile layout consistency**: On mobile, the Sizer header now matches the Designer page — logo and What's New centered at top, title and subtitle below
+- **Sizer: Default 2 Node cluster**: Default cluster changed from 3 Node / Three-Way Mirror to 2 Node / Two-Way Mirror, reducing the default starting hardware cost. Three-Way Mirror is automatically selected when 3+ nodes are configured
 - **Security: Removed invalid meta tags**: Removed `X-Frame-Options` and `X-XSS-Protection` meta tags from all pages (HTTP-header-only directives that are ineffective in `<meta>` tags; `X-Frame-Options` caused a console warning)
 - **Sizer: Bug Fixes**: vCPU ratio AUTO badge persistence, label correction, node recommendation memory cap, stale recommendation message, manual hardware override, node count reset, 1.5 TB memory threshold, memory headroom threshold (80%→85%), bidirectional memory & CPU auto-scaling, sizing notes reorder
 - **Sizer: Workload Analytics Tracking**: Each new workload added in the Sizer (VM, AKS, or AVD) is now tracked via tracking analytics, to display the "Sizes Calculated" on the main page stats bar

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -47,6 +47,8 @@ function showChangelog() {
                         <li><strong>Designer: Mobile stats bar 2×2:</strong> Page analytics bar displays as a 2×2 grid on mobile devices instead of a single row of 4.</li>
                         <li><strong>Sizer: "Estimated Power, Heat & Rack Space":</strong> Updated heading to include "Heat" since BTU/hr values are displayed; power units expanded to "Watts"; BTU is now a Wikipedia hyperlink.</li>
                         <li><strong>Sizer: Mobile header logo:</strong> ODIN logo and What's New text now visible on mobile, centered alongside header text.</li>
+                        <li><strong>Sizer: Mobile layout consistency:</strong> On mobile, the Sizer header now matches the Designer page — logo and What's New centered at top, title and subtitle below.</li>
+                        <li><strong>Sizer: Default 2 Node cluster:</strong> Default cluster changed from 3 Node / Three-Way Mirror to 2 Node / Two-Way Mirror, reducing the starting hardware cost. Three-Way Mirror is auto-selected when 3+ nodes are configured.</li>
                         <li><strong>Security: Removed invalid meta tags:</strong> Removed X-Frame-Options and X-XSS-Protection meta tags (HTTP-header-only, caused console warnings).</li>
                     </ul>
                     <h4 style="color: var(--accent-purple); margin: 16px 0 12px 0;">🐛 Sizer Bug Fixes</h4>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -120,8 +120,8 @@
                     <div class="config-row cluster-setting">
                         <label for="node-count">Number of Physical Nodes</label>
                         <select id="node-count" onchange="onNodeCountChange()">
-                            <option value="2">2 Nodes</option>
-                            <option value="3" selected>3 Nodes</option>
+                            <option value="2" selected>2 Nodes</option>
+                            <option value="3">3 Nodes</option>
                             <option value="4">4 Nodes</option>
                             <option value="5">5 Nodes</option>
                             <option value="6">6 Nodes</option>
@@ -151,8 +151,8 @@
                     <div class="config-row">
                         <label for="resiliency">Storage Resiliency</label>
                         <select id="resiliency" onchange="onResiliencyChange()">
-                            <option value="2way">Two-way Mirror (min 2 nodes)</option>
-                            <option value="3way" selected>Three-way Mirror (min 3 nodes)</option>
+                            <option value="2way" selected>Two-way Mirror (min 2 nodes)</option>
+                            <option value="3way">Three-way Mirror (min 3 nodes)</option>
                         </select>
                     </div>
                     <div class="config-info config-info-warning" id="resiliency-recommendation" style="display: none;">

--- a/sizer/sizer.css
+++ b/sizer/sizer.css
@@ -1344,29 +1344,33 @@ body {
     }
     
     .sizer-header {
-        flex-direction: row;
+        flex-direction: column;
         align-items: center;
-        gap: 24px;
+        text-align: center;
+        gap: 1rem;
+    }
+
+    .sizer-header .header-logo-wrapper {
+        order: -1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        margin-bottom: 0.5rem;
+    }
+
+    .sizer-header .header-logo-wrapper img {
+        max-height: 80px;
+    }
+
+    .sizer-header .header-version {
+        font-size: 11px;
+        white-space: normal;
+        text-align: center;
     }
 
     .sizer-header .header-content {
         flex: 1;
         min-width: 0;
-        padding-right: 4px;
-    }
-
-    .sizer-header .header-logo-wrapper {
-        display: flex;
-        flex-shrink: 0;
-    }
-
-    .sizer-header .header-logo-wrapper img {
-        max-height: 68px;
-    }
-
-    .sizer-header .header-version {
-        font-size: 11px;
-        white-space: nowrap;
     }
     
     .sizer-header h1 {

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -1537,7 +1537,7 @@ function updateNodeOptionsForClusterType() {
         if (nodeOptions.includes(currentValue)) {
             nodeSelect.value = currentValue;
         } else {
-            nodeSelect.value = 3;
+            nodeSelect.value = 2;
         }
     }
 }
@@ -3150,9 +3150,9 @@ function resetScenario() {
     document.getElementById('cluster-type').value = 'standard';
     updateNodeOptionsForClusterType();
     updateStorageForClusterType();
-    document.getElementById('node-count').value = '3';
+    document.getElementById('node-count').value = '2';
     updateResiliencyOptions();
-    document.getElementById('resiliency').value = '3way';
+    document.getElementById('resiliency').value = '2way';
     updateClusterInfo();
     renderWorkloads();
     calculateRequirements();


### PR DESCRIPTION
## Changes in v0.16.04

### Sizer Mobile Layout Consistency
- On mobile devices, the Sizer header now matches the Designer page layout — the ODIN logo and What's New link appear centered at the top, with the title and subtitle text immediately below
- Previously the logo and text were side-by-side on mobile, which was inconsistent with the Designer page

### Default Cluster Changed to 2 Node / Two-Way Mirror
- Default cluster configuration changed from Standard 3 Node to **Standard 2 Node**, reducing the default starting hardware cost
- Default storage resiliency changed from Three-Way Mirror to **Two-Way Mirror**, consistent with the 2-node minimum
- Three-Way Mirror is automatically selected when users configure 3+ nodes
- Auto-recommendation logic continues to scale up to 3+ nodes when workloads require it

### Files Changed
- **sizer/sizer.css** — Mobile header layout (flex-direction: column, order: -1 for logo)
- **sizer/index.html** — Default selected options for node count and resiliency
- **sizer/sizer.js** — Reset defaults and fallback node count
- **CHANGELOG.md** — Added new entries under v0.16.04
- **README.md** — Updated feature list and appendix
- **js/changelog.js** — Updated What's New modal