### PR TITLE
v0.16.04: Fix iOS Safari logo and What's New centering on mobile

### DIFF
--- a/sizer/sizer.css
+++ b/sizer/sizer.css
@@ -1344,28 +1344,45 @@ body {
     }
     
     .sizer-header {
+        display: -webkit-flex;
+        display: flex;
+        -webkit-flex-direction: column;
         flex-direction: column;
+        -webkit-align-items: center;
         align-items: center;
+        -webkit-justify-content: center;
+        justify-content: center;
         text-align: center;
         gap: 1rem;
     }
 
     .sizer-header .header-logo-wrapper {
         order: -1;
+        display: -webkit-flex;
         display: flex;
+        -webkit-flex-direction: column;
         flex-direction: column;
+        -webkit-align-items: center;
         align-items: center;
+        -webkit-justify-content: center;
+        justify-content: center;
+        width: 100%;
         margin-bottom: 0.5rem;
     }
 
     .sizer-header .header-logo-wrapper img {
         max-height: 100px;
+        display: block;
+        margin-left: auto;
+        margin-right: auto;
     }
 
     .sizer-header .header-version {
         font-size: 13px;
         white-space: normal;
         text-align: center;
+        width: 100%;
+        display: block;
     }
 
     .sizer-header .header-content {
@@ -1376,6 +1393,8 @@ body {
     .sizer-header h1 {
         font-size: 24px;
         text-align: center;
+        display: block;
+        width: 100%;
     }
     
     .sizer-header .subtitle {


### PR DESCRIPTION
## Changes

Fixes the logo and What's New link not centering properly on iOS Safari (tested on iPhone 16 Pro).

### Root Causes Fixed
- **Missing justify-content override**: Base .sizer-header uses justify-content: space-between, which was never overridden to center in the mobile media query
- **Logo wrapper lacked width: 100%**: Without explicit full width, Safari positioned the wrapper asymmetrically
- **Missing -webkit- flex prefixes**: iOS Safari (older WebKit) requires -webkit-flex, -webkit-align-items, etc.

### Additional Hardening
- Logo img now has display: block; margin: auto as a bulletproof centering fallback
- Version text div has width: 100%; display: block for reliable text-align: center
- h1 gets display: block; width: 100% for consistent centering