### PR TITLE
fix: resolve CVE-2026-27699 - upgrade basic-ftp to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -462,9 +463,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
-      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -672,7 +673,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1566079.tgz",
       "integrity": "sha512-MJfAEA1UfVhSs7fbSQOG4czavUp1ajfg6prlAN0+cmfa2zNjaIbvq8VneP7do1WAQQIvgNJWSMeP6UyI90gIlQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -776,6 +778,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1264,6 +1267,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -5,5 +5,8 @@
   },
   "dependencies": {
     "html-validate": "^10.7.0"
+  },
+  "overrides": {
+    "basic-ftp": ">=5.2.0"
   }
 }


### PR DESCRIPTION
## Security Fix

Resolves Dependabot alert #5: **CVE-2026-27699** (GHSA-5rq4-664w-9x2c)

### Vulnerability
- **Package**: basic-ftp (transitive dev dependency via puppeteer)
- **Severity**: Critical (CVSS 9.1)
- **Type**: Path traversal in \downloadToDir()\ — a malicious FTP server can write files outside the intended download directory
- **CWE**: CWE-22 (Path Traversal)

### Fix
Added an npm \overrides\ entry in package.json to force \asic-ftp\ >= 5.2.0, which contains the upstream fix. Verified \asic-ftp@5.2.0\ is now resolved in the lock file and \
pm audit\ reports 0 vulnerabilities.