### PR TITLE
fix: CSS nesting - move misplaced selectors out of .stat-value block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sizer Footer Fix**: Moved Privacy footer inside the `<main class="container">` element so it respects max-width and mobile padding rules
 - **Designer Step-Header Overflow**: Fixed "Unsure? Start with Sizer" button overlapping Step 04 (Cluster Configuration) header on narrow mobile screens — `.step-header` now uses `flex-wrap: wrap` and the sizer-link drops to its own full-width line
 - **Sizer Mobile Header Consistency**: Aligned logo size (80px), version text size (11px), and logo ordering (`order: -1`, logo above title) with the Designer's mobile layout
+- **CSS Nesting Fix**: Fixed invalid CSS nesting where `.onboarding-btn-primary:hover`, `.option-card:active`, and `.breadcrumb-item:active` rules were incorrectly nested inside the `.stat-value` declaration block — moved to top-level selectors
 
 ### Changed
 - **Designer Title**: Renamed from "Odin for Azure Local" to "ODIN Designer for Azure Local" for naming consistency with the Sizer

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Mobile Layout Fixes (iOS)**: Fixed Sizer header, disclaimer, stats bar, and Privacy footer not aligning with form panels on mobile devices; fixed Designer "Unsure? Start with Sizer" button overlapping Step 04 header on narrow screens
 - **Sizer Mobile Consistency**: Aligned Sizer mobile logo size (80px), version text (11px), and logo-above-title ordering to match the Designer
 - **Designer Title Update**: Renamed Designer title from "Odin for Azure Local" to "ODIN Designer for Azure Local" for consistency with the Sizer naming convention, this also adds clarity, given the expanded scope of ODIN, which includes the Knowledge and Sizer pages.
+- **CSS Nesting Fix**: Fixed invalid CSS nesting where `.onboarding-btn-primary:hover`, `.option-card:active`, and `.breadcrumb-item:active` rules were incorrectly nested inside the `.stat-value` declaration block — moved to top-level selectors
 
 > **Full Version History**: See [Appendix A - Version History](#appendix-a---version-history) for complete release notes.
 
@@ -353,6 +354,7 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 - **Designer Step-Header Overflow**: Fixed "Unsure? Start with Sizer" button overlapping Step 04 (Cluster Configuration) header on narrow mobile screens — step-header now wraps and sizer-link drops to its own line
 - **Sizer Mobile Header Consistency**: Aligned logo size (80px), version text size (11px), and logo ordering (logo above title) with the Designer's mobile layout
 - **Designer Title Update**: Renamed from "Odin for Azure Local" to "ODIN Designer for Azure Local" for naming consistency with the Sizer
+- **CSS Nesting Fix**: Fixed invalid CSS nesting where hover/active selectors were incorrectly nested inside `.stat-value` — moved to top-level
 
 #### 0.17.57 - Individual MANUAL Override Dismiss
 - **Per-Field Dismiss**: Each MANUAL badge now includes a small × button to remove that individual override without clearing all overrides

--- a/css/style.css
+++ b/css/style.css
@@ -2744,19 +2744,19 @@ header .header-description {
 .stat-value {
     color: var(--text-primary);
     font-weight: 600;
+}
 
-    .onboarding-btn-primary:hover {
-        transform: none;
-    }
+.onboarding-btn-primary:hover {
+    transform: none;
+}
 
-    /* Ensure tap feedback */
-    .option-card:active {
-        background: rgba(255, 255, 255, 0.08);
-    }
+/* Ensure tap feedback */
+.option-card:active {
+    background: rgba(255, 255, 255, 0.08);
+}
 
-    .breadcrumb-item:active {
-        background: rgba(255, 255, 255, 0.1);
-    }
+.breadcrumb-item:active {
+    background: rgba(255, 255, 255, 0.1);
 }
 
 /* Stats bar mobile - 2x2 grid (must be after base .stats-container) */

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -39,6 +39,7 @@ function showChangelog() { // eslint-disable-line no-unused-vars
                         <li><strong>Designer Step-Header Overflow:</strong> Fixed "Unsure? Start with Sizer" button overlapping Step 04 (Cluster Configuration) header on narrow mobile screens — the link now wraps to its own line.</li>
                         <li><strong>Sizer Mobile Header Consistency:</strong> Aligned logo size, version text size, and logo ordering (logo above title) with the Designer's mobile layout.</li>
                         <li><strong>Designer Title Update:</strong> Renamed from "Odin for Azure Local" to "ODIN Designer for Azure Local" for naming consistency with the Sizer.</li>
+                        <li><strong>CSS Nesting Fix:</strong> Fixed invalid CSS nesting where hover/active selectors were incorrectly nested inside <code>.stat-value</code> — moved to top-level selectors.</li>
                     </ul>
                 </div>
 


### PR DESCRIPTION
## Summary
Fixed invalid CSS nesting where .onboarding-btn-primary:hover, .option-card:active, and .breadcrumb-item:active rules were incorrectly nested inside the .stat-value declaration block in css/style.css. Without native CSS nesting support, these selectors would be ignored or cause unexpected behavior.

## Changes
- **css/style.css**: Moved three misplaced selectors out of .stat-value to top-level
- **README.md**: Added CSS nesting fix to 0.17.58 release notes (top section + appendix)
- **CHANGELOG.md**: Added CSS nesting fix to 0.17.58 entry
- **js/changelog.js**: Added CSS nesting fix to What's New dialog

## Testing
- Visual inspection confirms no layout regression
- The three selectors now apply correctly as independent rules