### PR TITLE
Fix changelog accuracy: remove BOM, correct dates, update CSS nesting description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sizer Footer Fix**: Moved Privacy footer inside the `<main class="container">` element so it respects max-width and mobile padding rules
 - **Designer Step-Header Overflow**: Fixed "Unsure? Start with Sizer" button overlapping Step 04 (Cluster Configuration) header on narrow mobile screens — `.step-header` now uses `flex-wrap: wrap` and the sizer-link drops to its own full-width line
 - **Sizer Mobile Header Consistency**: Aligned logo size (80px), version text size (11px), and logo ordering (`order: -1`, logo above title) with the Designer's mobile layout
-- **CSS Nesting Fix**: Fixed invalid CSS nesting where `.onboarding-btn-primary:hover`, `.option-card:active`, and `.breadcrumb-item:active` rules were incorrectly nested inside the `.stat-value` declaration block — moved to top-level selectors
+- **CSS Nesting Fix**: Corrected CSS for hover and active states of `.stat-value` elements so styles apply consistently across browsers
 
 ### Changed
 - **Designer Title**: Renamed from "Odin for Azure Local" to "ODIN Designer for Azure Local" for naming consistency with the Sizer

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Mobile Layout Fixes (iOS)**: Fixed Sizer header, disclaimer, stats bar, and Privacy footer not aligning with form panels on mobile devices; fixed Designer "Unsure? Start with Sizer" button overlapping Step 04 header on narrow screens
 - **Sizer Mobile Consistency**: Aligned Sizer mobile logo size (80px), version text (11px), and logo-above-title ordering to match the Designer
 - **Designer Title Update**: Renamed Designer title from "Odin for Azure Local" to "ODIN Designer for Azure Local" for consistency with the Sizer naming convention, this also adds clarity, given the expanded scope of ODIN, which includes the Knowledge and Sizer pages.
-- **CSS Nesting Fix**: Fixed invalid CSS nesting where `.onboarding-btn-primary:hover`, `.option-card:active`, and `.breadcrumb-item:active` rules were incorrectly nested inside the `.stat-value` declaration block — moved to top-level selectors
+- **CSS Nesting Fix**: Corrected CSS for hover and active states of `.stat-value` elements so styles apply consistently across browsers
 
 > **Full Version History**: See [Appendix A - Version History](#appendix-a---version-history) for complete release notes.
 
@@ -354,7 +354,7 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 - **Designer Step-Header Overflow**: Fixed "Unsure? Start with Sizer" button overlapping Step 04 (Cluster Configuration) header on narrow mobile screens — step-header now wraps and sizer-link drops to its own line
 - **Sizer Mobile Header Consistency**: Aligned logo size (80px), version text size (11px), and logo ordering (logo above title) with the Designer's mobile layout
 - **Designer Title Update**: Renamed from "Odin for Azure Local" to "ODIN Designer for Azure Local" for naming consistency with the Sizer
-- **CSS Nesting Fix**: Fixed invalid CSS nesting where hover/active selectors were incorrectly nested inside `.stat-value` — moved to top-level
+- **CSS Nesting Fix**: Corrected CSS for hover and active states of `.stat-value` elements so styles apply consistently across browsers
 
 #### 0.17.57 - Individual MANUAL Override Dismiss
 - **Per-Field Dismiss**: Each MANUAL badge now includes a small × button to remove that individual override without clearing all overrides

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -1,4 +1,4 @@
-﻿// Shared changelog modal - loaded by both Designer and Sizer pages
+// Shared changelog modal - loaded by both Designer and Sizer pages
 // Show changelog/what's new
 function showChangelog() { // eslint-disable-line no-unused-vars
     const overlay = document.createElement('div');
@@ -39,7 +39,7 @@ function showChangelog() { // eslint-disable-line no-unused-vars
                         <li><strong>Designer Step-Header Overflow:</strong> Fixed "Unsure? Start with Sizer" button overlapping Step 04 (Cluster Configuration) header on narrow mobile screens — the link now wraps to its own line.</li>
                         <li><strong>Sizer Mobile Header Consistency:</strong> Aligned logo size, version text size, and logo ordering (logo above title) with the Designer's mobile layout.</li>
                         <li><strong>Designer Title Update:</strong> Renamed from "Odin for Azure Local" to "ODIN Designer for Azure Local" for naming consistency with the Sizer.</li>
-                        <li><strong>CSS Nesting Fix:</strong> Fixed invalid CSS nesting where hover/active selectors were incorrectly nested inside <code>.stat-value</code> — moved to top-level selectors.</li>
+                        <li><strong>CSS Nesting Fix:</strong> Corrected CSS for hover and active states of <code>.stat-value</code> elements so styles apply consistently across browsers.</li>
                     </ul>
                 </div>
 
@@ -908,7 +908,7 @@ function showChangelog() { // eslint-disable-line no-unused-vars
 
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
                     <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.10.2</h4>
-                    <div style="font-size: 13px; color: var(--text-secondary);">January 20, 2025</div>
+                    <div style="font-size: 13px; color: var(--text-secondary);">January 20, 2026</div>
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
@@ -1228,7 +1228,7 @@ function showChangelog() { // eslint-disable-line no-unused-vars
 
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(139, 92, 246, 0.05); border-left: 3px solid var(--accent-purple); border-radius: 4px;">
                     <h4 style="margin: 0 0 8px 0; color: var(--accent-purple);">Version 0.4.3</h4>
-                    <div style="font-size: 13px; color: var(--text-secondary);">June 26, 2025</div>
+                    <div style="font-size: 13px; color: var(--text-secondary);">December 17, 2025</div>
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">


### PR DESCRIPTION
## Summary
Fixes 5 review findings from the CSS nesting PR.

### Changes
- **Remove UTF-8 BOM** from `js/changelog.js` — unnecessary BOM that can cause issues with some tools
- **Fix v0.10.2 date** from *January 20, 2025* → *January 20, 2026*
- **Fix v0.4.3 date** from *June 26, 2025* → *December 17, 2025*
- **Update CSS Nesting Fix description** to accurately reflect what was changed, across `js/changelog.js`, `README.md`, and `CHANGELOG.md`
- **Verified Dec 2025 dates** for v0.4.x–v0.8.x are correct (tool was created in Nov/Dec 2025)

### Files Modified
- `CHANGELOG.md`
- `README.md`
- `js/changelog.js`