### PR TITLE
Fix changelog modal: JSDoc, label cleanup, Escape key support

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -1,7 +1,27 @@
 // Shared changelog modal - loaded by both Designer and Sizer pages
 // Show changelog/what's new
-function showChangelog() { // eslint-disable-line no-unused-vars
+/**
+ * Opens the shared "What's New" changelog modal.
+ * Intended to be called from HTML (e.g. onclick handlers).
+ * @global
+ */
+function showChangelog() {
     const overlay = document.createElement('div');
+
+    // Reusable close handler — used by X button, overlay click, and Escape key.
+    const closeChangelog = () => {
+        document.removeEventListener('keydown', onKeyDown);
+        if (overlay.parentElement) {
+            overlay.parentElement.removeChild(overlay);
+        }
+        if (window.closeChangelog === closeChangelog) {
+            try { delete window.closeChangelog; } catch (_) { window.closeChangelog = undefined; }
+        }
+    };
+    const onKeyDown = (e) => {
+        if (e.key === 'Escape' || e.key === 'Esc') closeChangelog();
+    };
+    window.closeChangelog = closeChangelog;
     overlay.style.cssText = `
         position: fixed;
         top: 0;
@@ -22,12 +42,12 @@ function showChangelog() { // eslint-disable-line no-unused-vars
         <div style="background: var(--card-bg); border: 1px solid var(--glass-border); border-radius: 16px; padding: 20px; max-width: 700px; width: 100%; max-height: 90vh; overflow-y: auto; box-sizing: border-box;">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
                 <h3 style="margin: 0; color: var(--accent-blue); font-size: 18px;">What's New</h3>
-                <button onclick="this.parentElement.parentElement.parentElement.remove()" style="background: transparent; border: none; color: var(--text-secondary); font-size: 28px; cursor: pointer; padding: 0 8px; line-height: 1;">&times;</button>
+                <button onclick="closeChangelog()" style="background: transparent; border: none; color: var(--text-secondary); font-size: 28px; cursor: pointer; padding: 0 8px; line-height: 1;">&times;</button>
             </div>
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.17.58 - Latest Release</h4>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.17.58</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">March 2, 2026</div>
                 </div>
 
@@ -1373,8 +1393,12 @@ function showChangelog() { // eslint-disable-line no-unused-vars
     `;
 
     overlay.addEventListener('click', (e) => {
-        if (e.target === overlay) overlay.remove();
+        if (e.target === overlay) {
+            window.closeChangelog && window.closeChangelog();
+        }
     });
 
     document.body.appendChild(overlay);
+    // Allow closing the modal with the Escape key for accessibility.
+    document.addEventListener('keydown', onKeyDown);
 }


### PR DESCRIPTION
## Changes

- **JSDoc @global annotation**: Replaced eslint-disable comment with proper JSDoc documenting that showChangelog() is intentionally globally accessible (called from HTML onclick handlers).
- **Remove hardcoded 'Latest Release' label**: Version header now reads just 'Version 0.17.58' — eliminates a manual update step on every release.
- **Escape key support**: Added a reusable closeChangelog() handler so the modal can be dismissed via the X button, clicking outside, or pressing Escape. Keydown listener is cleaned up on close to avoid leaks.