### PR TITLE
Fix changelog modal cleanup and overlay click listener leak

### DIFF
--- a/js/changelog.js
+++ b/js/changelog.js
@@ -11,11 +11,17 @@ function showChangelog() {
     // Reusable close handler — used by X button, overlay click, and Escape key.
     const closeChangelog = () => {
         document.removeEventListener('keydown', onKeyDown);
+        overlay.removeEventListener('click', onOverlayClick);
         if (overlay.parentElement) {
             overlay.parentElement.removeChild(overlay);
         }
         if (window.closeChangelog === closeChangelog) {
-            try { delete window.closeChangelog; } catch (_) { window.closeChangelog = undefined; }
+            window.closeChangelog = undefined;
+        }
+    };
+    const onOverlayClick = (e) => {
+        if (e.target === overlay) {
+            window.closeChangelog && window.closeChangelog();
         }
     };
     const onKeyDown = (e) => {
@@ -1392,11 +1398,7 @@ function showChangelog() {
         </div>
     `;
 
-    overlay.addEventListener('click', (e) => {
-        if (e.target === overlay) {
-            window.closeChangelog && window.closeChangelog();
-        }
-    });
+    overlay.addEventListener('click', onOverlayClick);
 
     document.body.appendChild(overlay);
     // Allow closing the modal with the Escape key for accessibility.


### PR DESCRIPTION
## Changes

- **Simplified window cleanup**: Replaced overly defensive \	ry { delete window.closeChangelog; } catch (_) { ... }\ with a direct \window.closeChangelog = undefined\ assignment. The property is dynamically assigned and configurable, so the try-catch is unnecessary.

- **Fixed overlay click listener leak**: Extracted the anonymous overlay click handler into a named \onOverlayClick\ function and added \overlay.removeEventListener('click', onOverlayClick)\ in the \closeChangelog()\ cleanup. Previously, the anonymous listener was never removed, causing a memory leak when the modal was opened and closed multiple times.