### PR TITLE
Publish v0.17.61 - Fix Sizer Resume Session Banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.17.61] - 2026-03-09
+
+### Fixed
+
+#### Sizer: Fix Resume Session Banner
+- **Fix Resume Banner**: Fixed the "Previous Sizer Session Found" banner appearing unconditionally on every page load, even when no workloads were added — the banner now only appears when there are actual workloads to resume (fixes #178)
+- **Fix Start Fresh Re-Save**: Fixed `startSizerFresh()` immediately re-saving default state via `calculateRequirements()` → `saveSizerState()`, causing the banner to reappear on the next page load
+
+---
+
 ## [0.17.60] - 2026-03-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.17.60 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.17.61 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) architectures. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts. The Sizer Tool (preview) can be used to provide example cluster hardware configurations, based on your workload scenarios and capacity requirements.
 
@@ -40,9 +40,8 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.17.60 - Latest Release
-- **Sizer: Intel® 6th Gen Xeon® (Granite Rapids / Sierra Forest)**: Expanded the Intel® 6th Gen Xeon® CPU generation in the Sizer to cover the full 8–172 core range from the Azure Local hardware catalog, and set it as the default Intel CPU selection
-- **Sizer: Updated Intel Default**: Intel CPU default changed from 5th Gen Xeon® (Emerald Rapids) to Intel® 6th Gen Xeon® (Granite Rapids / Sierra Forest)
+### 🎉 Version 0.17.61 - Latest Release
+- **Sizer: Fix Resume Session Banner**: Fixed the "Previous Sizer Session Found" banner appearing unconditionally on every page load, even when no workloads were added — the banner now only appears when there are actual workloads to resume (fixes #178)
 
 > **Full Version History**: See [Appendix A - Version History](#appendix-a---version-history) for complete release notes.
 
@@ -330,7 +329,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.17.60  
+**Version**: 0.17.61  
 **Last Updated**: March 2026  
 **Compatibility**: Azure Local 2506+
 
@@ -345,6 +344,10 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.17.x Series (February - March 2026)
+
+#### 0.17.61 - Sizer: Fix Resume Session Banner
+- **Fix Resume Banner**: Fixed the "Previous Sizer Session Found" banner appearing unconditionally on every page load, even when no workloads were added — the banner now only appears when there are actual workloads to resume (fixes #178)
+- **Fix Start Fresh Re-Save**: Fixed "Start Fresh" immediately re-saving default state, causing the banner to reappear on the next page load
 
 #### 0.17.60 - Sizer: Intel® 6th Gen Xeon® (Granite Rapids / Sierra Forest)
 - **Intel® 6th Gen Xeon® Expanded**: Expanded the Intel® 6th Gen Xeon® CPU generation in the Sizer to cover the full 8–172 core range from the Azure Local hardware catalog

--- a/index.html
+++ b/index.html
@@ -505,7 +505,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.17.60 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.17.61 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -53,9 +53,20 @@ function showChangelog() {
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.17.60</h4>
-                    <div style="font-size: 13px; color: var(--text-secondary);">March 3, 2026</div>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.17.61</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">March 9, 2026</div>
                 </div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 Sizer: Fix Resume Session Banner (fixes <a href="https://github.com/Azure/odinforazurelocal/issues/178" target="_blank">#178</a>)</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Fix Resume Banner:</strong> Fixed the "Previous Sizer Session Found" banner appearing unconditionally on every page load, even when no workloads were added — the banner now only appears when there are actual workloads to resume.</li>
+                        <li><strong>Fix Start Fresh Re-Save:</strong> Fixed "Start Fresh" immediately re-saving default state, causing the banner to reappear on the next page load.</li>
+                    </ul>
+                </div>
+
+                <hr style="border: none; border-top: 2px solid var(--glass-border); margin: 24px 0;">
+                <div style="font-size: 12px; color: var(--text-secondary); margin-bottom: 16px;">Previous: Version 0.17.60</div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
                     <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">⚙️ Sizer: Intel® 6th Gen Xeon® (Granite Rapids / Sierra Forest)</h4>

--- a/js/script.js
+++ b/js/script.js
@@ -1,5 +1,5 @@
 ﻿// Odin for Azure Local - version for tracking changes
-const WIZARD_VERSION = '0.17.60';
+const WIZARD_VERSION = '0.17.61';
 const WIZARD_STATE_KEY = 'azureLocalWizardState';
 const WIZARD_TIMESTAMP_KEY = 'azureLocalWizardTimestamp';
 

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -34,7 +34,7 @@
                 <div class="header-logo-wrapper">
                     <img src="../images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.17.60 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
+                        Version 0.17.61 | <a href="#" onclick="event.preventDefault(); showChangelog();" class="whats-new-link">What's New</a>
                     </div>
                 </div>
             </div>

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -1770,12 +1770,10 @@ function checkForSavedSizerState() {
     const saved = loadSizerState();
     if (!saved || !saved.data) return;
 
-    // Only show if there are workloads or non-default settings
+    // Only show if there are actual workloads to resume
     const d = saved.data;
     const hasWorkloads = d.workloads && d.workloads.length > 0;
-    const hasNonDefaults = (d.clusterType !== 'standard' && d.clusterType !== 'aldo-mgmt' && d.clusterType !== 'aldo-wl') || d.nodeCount !== '3' ||
-        d.resiliency !== '3way' || d.futureGrowth !== '0';
-    if (!hasWorkloads && !hasNonDefaults) return;
+    if (!hasWorkloads) return;
 
     const timestamp = saved.timestamp ? new Date(saved.timestamp).toLocaleString() : 'Unknown time';
     const workloadCount = d.workloads ? d.workloads.length : 0;
@@ -1958,6 +1956,8 @@ function startSizerFresh() {
     clearSizerState();
     dismissSizerResumeBanner();
     resetScenario();
+    // resetScenario → calculateRequirements re-saves state; clear it again
+    clearSizerState();
 }
 
 // Dismiss the resume banner


### PR DESCRIPTION
## Changes

### Sizer: Fix Resume Session Banner (fixes #178)

**Bug**: The 'Previous Sizer Session Found' banner appeared unconditionally on every Sizer page load, even when no workloads were added. Clicking 'Resume' loaded nothing meaningful, and clicking 'Start Fresh' did not prevent the banner from reappearing on the next visit.

**Root Cause**:
1. \checkForSavedSizerState()\ compared saved state against wrong default values (\'3'\/\'3way'\ vs actual defaults \'2'\/\'2way'\), so the \hasNonDefaults\ check always returned true
2. \startSizerFresh()\ called \esetScenario()\ which re-saved default state via \calculateRequirements()\ → \saveSizerState()\

**Fix**:
- Resume banner now only appears when saved state contains actual workloads
- \startSizerFresh()\ clears state after \esetScenario()\ to prevent re-save

### Version Bump
- Version bumped to **0.17.61** in all locations (index.html, sizer/index.html, js/script.js)
- Release notes added to README.md, CHANGELOG.md, and What's New modal

Closes #178