### PR TITLE
Fix DDA acronym: Discrete Device Assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### Sizer: GPU Capacity Planning (closes #180)
-- **GPU Workload Requirements**: All three workload types (Azure Local VMs, AKS Arc, AVD) now support GPU mode selection — DDA (Direct Device Assignment) and GPU-P (GPU Partitioning)
+- **GPU Workload Requirements**: All three workload types (Azure Local VMs, AKS Arc, AVD) now support GPU mode selection — DDA (Discrete Device Assignment) and GPU-P (GPU Partitioning)
 - **GPU Model Selectors**: DDA and GPU-P modes include GPU model dropdowns that auto-set hardware GPU type and enforce homogeneous configuration across all workloads and nodes
 - **Homogeneous GPU Locking**: Once a workload selects a GPU model, the hardware GPU Type is locked (disabled with WORKLOAD badge) and all subsequent workload GPU selectors are locked to the same model
 - **Per-Model GPU-P Partitions**: GPU-P partition sizes dynamically filter based on the selected GPU model, showing VRAM per partition (e.g., A2 supports up to 1:8, L40S supports up to 1:16)

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 ### 🎉 Version 0.18.x Series (March 2026)
 
 #### 0.18.01 - Sizer: GPU Capacity Planning & Total VM Requirements
-- **Sizer: GPU Capacity Planning ([#180](https://github.com/Azure/odinforazurelocal/issues/180))**: Full GPU capacity planning based on workload requirements — supports DDA (Direct Device Assignment) and GPU-P (GPU Partitioning) modes across Azure Local VMs, AKS Arc, and AVD workloads
+- **Sizer: GPU Capacity Planning ([#180](https://github.com/Azure/odinforazurelocal/issues/180))**: Full GPU capacity planning based on workload requirements — supports DDA (Discrete Device Assignment) and GPU-P (GPU Partitioning) modes across Azure Local VMs, AKS Arc, and AVD workloads
 - **GPU Model Selectors**: DDA and GPU-P modes include GPU model dropdowns that auto-set hardware GPU type and enforce homogeneous configuration across all workloads and nodes (with WORKLOAD badge on locked hardware GPU Type)
 - **Per-Model GPU-P Partitions**: GPU-P partition sizes dynamically filter based on the selected GPU model, showing VRAM per partition (e.g., A2 supports up to 1:8 / 2 GB, L40S supports up to 1:16 / 3 GB)
 - **GPU Capacity Bar**: New GPU capacity bar chart showing consumed vs available GPUs with N−1 node awareness for maintenance/drain reserve

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -577,7 +577,7 @@ function getGpuRequirementFields(workloadType) {
             </label>
             <select id="wl-gpu-mode" onchange="toggleWorkloadGpuFields()">
                 <option value="none" selected>None</option>
-                <option value="dda">DDA (Direct Device Assignment)</option>
+                <option value="dda">DDA (Discrete Device Assignment)</option>
                 ${gpuPOption}
             </select>
             ${gpuPNote}


### PR DESCRIPTION
Corrects the DDA acronym expansion from 'Direct Device Assignment' to 'Discrete Device Assignment' in the sizer dropdown, README, and CHANGELOG.