### PR TITLE
Fix NIC overrideAdapterProperty not set when RDMA disabled (fixes #187) - v0.18.02

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1651,7 +1651,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.10.2] - 2025-01-20
+## [0.10.2] - 2026-01-20
 
 ### Changed
 
@@ -1671,7 +1671,7 @@ This change provides a clearer user experience since SDN is optional and is not 
 
 ---
 
-## [0.10.1] - 2025-01-19
+## [0.10.1] - 2026-01-19
 
 ### Fixed
 
@@ -1686,7 +1686,7 @@ This ensures that when users import a previously exported ARM template, these im
 
 ---
 
-## [0.10.0] - 2025-01-19
+## [0.10.0] - 2026-01-19
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.18.02] - 2026-03-26
+
+### Fixed
+
+#### Designer: Fix NIC overrideAdapterProperty (fixes #187)
+- **Fix `overrideAdapterProperty` flag**: Fixed a bug where disabling RDMA on NICs assigned to the Management+Compute intent (e.g., in a switchless 4+ NIC configuration) would generate `"overrideAdapterProperty": false` in the ARM parameter JSON instead of `true` — the adapterPropertyOverrides (networkDirect: Disabled) were present but not enforced
+- **NIC-Level RDMA Detection**: `buildAdapterPropertyOverrides()` now accepts the group's NIC list and checks `portConfig[i].rdmaManual` — if any NIC in the group had its RDMA manually changed at Step 07, the override flag is set
+- **Auto-Disable Flag**: When `renderIntentOverrides()` auto-disables RDMA for an intent group because no NICs are RDMA-capable, `__touchedAdapterProperty` is now set so the generated JSON correctly includes `overrideAdapterProperty: true`
+
+---
+
 ## [0.18.01] - 2026-03-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.18.01 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.18.02 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) architectures. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts. The Sizer Tool (preview) can be used to provide example cluster hardware configurations, based on your workload scenarios and capacity requirements.
 
@@ -40,15 +40,8 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.18.01 - Latest Release
-- **Sizer: GPU Capacity Planning ([#180](https://github.com/Azure/odinforazurelocal/issues/180))**: Full GPU capacity planning based on workload requirements — supports DDA and GPU-P modes across Azure Local VMs, AKS Arc, and AVD workloads with N−1 node awareness, auto-scaling of GPU count per node and physical nodes, and a new GPU capacity bar chart
-- **Sizer: Total VM Requirements ([#181](https://github.com/Azure/odinforazurelocal/issues/181))**: New "Total VM Requirements" input mode for Azure Local VMs — enter aggregate vCPU, memory, and storage totals directly instead of per-VM sizing
-- **Sizer: GPU Model Selectors**: DDA and GPU-P modes now include GPU model dropdowns — selecting a model auto-sets the hardware GPU type and enforces homogeneous configuration across all workloads and nodes
-- **Sizer: Per-Model GPU-P Partitions**: GPU-P partition sizes dynamically filter based on the selected GPU model, showing VRAM per partition (e.g., A2 supports up to 1:8, L40S supports up to 1:16)
-- **Sizer: GPU Models Expanded**: Added NVIDIA T4, RTX Pro 6000, and H100 models with correct maxPerNode limits (up to 4 per node for L40S, L4, H100)
-- **Sizer: AKS GPU VM Sizes**: AKS workloads now show all supported GPU-enabled VM SKUs with fixed vCPU/memory per size, auto-setting hardware GPU type on selection
-- **Sizer: GPU Auto-Scaling**: GPU demand now drives node count recommendations and GPUs-per-node auto-scaling (with AUTO badge) up to the model's maximum
-- **Sizer: 3:1 vCPU Overcommit Ratio**: Added the missing 3:1 option to the vCPU overcommit ratio dropdown
+### 🎉 Version 0.18.02 - Latest Release
+- **Designer: Fix NIC `overrideAdapterProperty` ([#187](https://github.com/Azure/odinforazurelocal/issues/187))**: Fixed a bug where disabling RDMA on NICs assigned to the Management+Compute intent (e.g., in a switchless 4+ NIC configuration) would generate `"overrideAdapterProperty": false` in the ARM parameter JSON instead of `true` — the override flag now correctly activates when NIC-level RDMA is changed at Step 07 or auto-disabled at Step 08
 
 > **Full Version History**: See [Appendix A - Version History](#appendix-a---version-history) for complete release notes.
 
@@ -351,6 +344,11 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.18.x Series (March 2026)
+
+#### 0.18.02 - Designer: Fix NIC overrideAdapterProperty (#187)
+- **Fix NIC `overrideAdapterProperty` ([#187](https://github.com/Azure/odinforazurelocal/issues/187))**: Fixed a bug where disabling RDMA on NICs assigned to the Management+Compute intent (e.g., in a switchless 4+ NIC configuration) would generate `"overrideAdapterProperty": false` in the ARM parameter JSON instead of `true`
+- **NIC-Level RDMA Detection**: The ARM intent generator now detects NIC-level RDMA changes made at Step 07 (Port Configuration) and correctly sets the override flag
+- **Auto-Disable Flag**: When Step 08 (Intent Overrides) auto-disables RDMA for an intent group because no NICs are RDMA-capable, the adapter property touched flag is now set
 
 #### 0.18.01 - Sizer: GPU Capacity Planning & Total VM Requirements
 - **Sizer: GPU Capacity Planning ([#180](https://github.com/Azure/odinforazurelocal/issues/180))**: Full GPU capacity planning based on workload requirements — supports DDA (Discrete Device Assignment) and GPU-P (GPU Partitioning) modes across Azure Local VMs, AKS Arc, and AVD workloads

--- a/css/style.css
+++ b/css/style.css
@@ -10,6 +10,7 @@
     --glass-border: rgba(255, 255, 255, 0.1);
     --subtle-bg: rgba(255, 255, 255, 0.03);
     --subtle-bg-hover: rgba(255, 255, 255, 0.06);
+    --nav-height: 56px;
 }
 
 * {
@@ -30,7 +31,7 @@ body {
 /* Breadcrumb Navigation */
 .breadcrumb-nav {
     position: sticky;
-    top: 56px; /* Account for fixed nav bar height */
+    top: var(--nav-height); /* Account for fixed nav bar height */
     z-index: 100;
     background: var(--nav-bg);
     backdrop-filter: blur(20px);
@@ -155,7 +156,7 @@ body {
 /* Animated Step Transitions */
 .step {
     animation: stepFadeIn 0.4s ease-out;
-    scroll-margin-top: 140px; /* Account for fixed nav (56px) + sticky breadcrumb (~80px) */
+    scroll-margin-top: 140px; /* Account for fixed nav (--nav-height) + sticky breadcrumb (~80px) */
 }
 
 @keyframes stepFadeIn {

--- a/index.html
+++ b/index.html
@@ -505,7 +505,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.18.01 | <button type="button" onclick="showChangelog();" class="whats-new-link">What's New</button>
+                        Version 0.18.02 | <button type="button" onclick="showChangelog();" class="whats-new-link">What's New</button>
                     </div>
                 </div>
             </div>

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -53,12 +53,24 @@ function showChangelog() { // eslint-disable-line no-unused-vars
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.18.01</h4>
-                    <div style="font-size: 13px; color: var(--text-secondary);">March 20, 2026</div>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.18.02</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">March 26, 2026</div>
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
-                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🎮 Sizer: GPU Capacity Planning (closes <a href="https://github.com/Azure/odinforazurelocal/issues/180" target="_blank">#180</a>)</h4>
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 Designer: Fix NIC overrideAdapterProperty (fixes <a href="https://github.com/Azure/odinforazurelocal/issues/187" target="_blank">#187</a>)</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Fix overrideAdapterProperty:</strong> Fixed a bug where disabling RDMA on NICs assigned to the Management+Compute intent (e.g., in a switchless 4+ NIC configuration) would generate <code>"overrideAdapterProperty": false</code> in the ARM parameter JSON instead of <code>true</code>.</li>
+                        <li><strong>NIC-Level RDMA Detection:</strong> The ARM intent generator now detects NIC-level RDMA changes made at Step 07 (Port Configuration) and correctly sets the override flag.</li>
+                        <li><strong>Auto-Disable Flag:</strong> When Step 08 auto-disables RDMA for an intent group because no NICs are RDMA-capable, the adapter property touched flag is now set.</li>
+                    </ul>
+                </div>
+
+                <hr style="border: none; border-top: 2px solid var(--glass-border); margin: 24px 0;">
+                <div style="font-size: 12px; color: var(--text-secondary); margin-bottom: 16px;">Previous: Version 0.18.01</div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--text-secondary); margin: 0 0 12px 0;">🎮 Sizer: GPU Capacity Planning (closes <a href="https://github.com/Azure/odinforazurelocal/issues/180" target="_blank">#180</a>)</h4>
                     <ul style="margin: 0; padding-left: 20px;">
                         <li><strong>GPU Workload Requirements:</strong> All three workload types (Azure Local VMs, AKS Arc, AVD) now support GPU mode selection — DDA and GPU-P.</li>
                         <li><strong>GPU Model Selectors:</strong> DDA and GPU-P modes include GPU model dropdowns with homogeneous locking — once a GPU model is selected, it's enforced across all workloads and the hardware config (WORKLOAD badge).</li>
@@ -73,7 +85,7 @@ function showChangelog() { // eslint-disable-line no-unused-vars
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
-                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">📊 Sizer: Total VM Requirements (closes <a href="https://github.com/Azure/odinforazurelocal/issues/181" target="_blank">#181</a>)</h4>
+                    <h4 style="color: var(--text-secondary); margin: 0 0 12px 0;">📊 Sizer: Total VM Requirements (closes <a href="https://github.com/Azure/odinforazurelocal/issues/181" target="_blank">#181</a>)</h4>
                     <ul style="margin: 0; padding-left: 20px;">
                         <li><strong>Total VM Input Mode:</strong> New "Total VM Requirements" option — enter aggregate vCPU, memory, storage, and GPU totals directly.</li>
                         <li><strong>Input Mode First:</strong> Input Mode selector is now the first field in the VM modal.</li>
@@ -81,7 +93,7 @@ function showChangelog() { // eslint-disable-line no-unused-vars
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
-                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">⚙️ Sizer: 3:1 vCPU Overcommit Ratio</h4>
+                    <h4 style="color: var(--text-secondary); margin: 0 0 12px 0;">⚙️ Sizer: 3:1 vCPU Overcommit Ratio</h4>
                     <ul style="margin: 0; padding-left: 20px;">
                         <li><strong>3:1 Option:</strong> Added the missing 3:1 vCPU overcommit ratio to the Advanced Settings dropdown.</li>
                     </ul>

--- a/js/script.js
+++ b/js/script.js
@@ -1760,12 +1760,17 @@ function generateArmParameters() {
                 });
             };
 
-            const buildAdapterPropertyOverrides = (groupKey) => {
+            const buildAdapterPropertyOverrides = (groupKey, groupNicNumbers) => {
                 const ov = (state.intentOverrides && state.intentOverrides[groupKey]) ? state.intentOverrides[groupKey] : null;
-                const touched = !!(ov && (
+                // Check if any NIC in this group had its RDMA manually changed at Step 07 (#187).
+                const nicLevelManualRdma = Array.isArray(groupNicNumbers) && groupNicNumbers.some(n => {
+                    const pc = state.portConfig && state.portConfig[n - 1];
+                    return pc && pc.rdmaManual === true;
+                });
+                const touched = !!(nicLevelManualRdma || (ov && (
                     ov.__touchedAdapterProperty === true ||
                     (ov.__touched === true && ov.__touchedAdapterProperty === undefined && ov.__touchedVswitch === undefined && ov.__touchedVlan === undefined)
-                ));
+                )));
 
                 const jumbo = ov && ov.jumboFrames ? String(ov.jumboFrames) : '';
                 const rdmaMode = ov && ov.rdmaMode ? String(ov.rdmaMode) : '';
@@ -1850,7 +1855,7 @@ function generateArmParameters() {
                     ? getStorageAdapterNamesForIntent(g.nics)
                     : (Array.isArray(g.nics) ? g.nics : []).map(n => armAdapterNameForNic(n));
 
-                const adapterOverrides = buildAdapterPropertyOverrides(g.key);
+                const adapterOverrides = buildAdapterPropertyOverrides(g.key, g.nics);
                 const vswitchOverrides = buildVirtualSwitchConfigurationOverrides(g.key);
                 const qosOverrides = buildQosPolicyOverrides(g.key);
 
@@ -5542,8 +5547,11 @@ function renderIntentOverrides(container) {
         });
 
         // If no NICs in the group have RDMA enabled, auto-set rdmaMode to 'Disabled'
+        // and mark adapter property as touched so overrideAdapterProperty is set in the output (#187).
         if (!groupHasRdma && ov.rdmaMode !== 'Disabled') {
             ov.rdmaMode = 'Disabled';
+            ov.__touched = true;
+            ov.__touchedAdapterProperty = true;
         }
 
         const card = document.createElement('div');

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -34,7 +34,7 @@
                 <div class="header-logo-wrapper">
                     <img src="../images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.18.01 | <button type="button" onclick="showChangelog();" class="whats-new-link">What's New</button>
+                        Version 0.18.02 | <button type="button" onclick="showChangelog();" class="whats-new-link">What's New</button>
                     </div>
                 </div>
             </div>

--- a/sizer/sizer.css
+++ b/sizer/sizer.css
@@ -18,6 +18,7 @@
     --glass-border: rgba(255, 255, 255, 0.1);
     --subtle-bg: rgba(255, 255, 255, 0.03);
     --subtle-bg-hover: rgba(255, 255, 255, 0.06);
+    --nav-height: 56px;
 }
 
 * {
@@ -32,7 +33,7 @@ body {
     font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
     line-height: 1.6;
     min-height: 100vh;
-    padding-top: 56px;
+    padding-top: var(--nav-height);
 }
 
 /* Tab Navigation */
@@ -54,7 +55,7 @@ body {
     display: flex;
     align-items: center;
     gap: 8px;
-    height: 56px;
+    height: var(--nav-height);
 }
 
 .odin-tab-logo {
@@ -1462,7 +1463,7 @@ header .header-description {
     }
 
     body {
-        padding-top: 56px;
+        padding-top: var(--nav-height);
     }
     
     .container {


### PR DESCRIPTION
## Summary

Fixes [#187](https://github.com/Azure/odinforazurelocal/issues/187) — NIC `overrideAdapterProperty` does not set to `true` when RDMA is disabled on Management+Compute intent NICs.

### Problem

When a user disables RDMA on NICs assigned to the Management+Compute intent (e.g., in a Hyperconverged Switchless configuration with 4+ NICs), the generated ARM parameter JSON incorrectly outputs `overrideAdapterProperty: false` for the MgmtCompute intent. This means the `adapterPropertyOverrides` (including `networkDirect: Disabled`) are present but not enforced during deployment.

### Root Cause

There are two separate paths for configuring RDMA:
1. **Step 07 (Port Configuration)** — NIC-level RDMA checkboxes update `state.portConfig` but never set `state.intentOverrides[groupKey].__touchedAdapterProperty`
2. **Step 08 (Intent Overrides)** — Intent-level RDMA dropdown calls `updateIntentGroupOverride()` which does set the flag

When a user disables RDMA per-NIC at Step 07, the Step 08 RDMA dropdown is auto-disabled (greyed out) because no NICs in the group are RDMA-capable. Since the user can't interact with it, `__touchedAdapterProperty` is never set, and the JSON generator outputs `overrideAdapterProperty: false`.

### Fix

1. **`renderIntentOverrides()`** — When auto-disabling RDMA for an intent group (because no NICs have RDMA), now also sets `__touched` and `__touchedAdapterProperty = true`
2. **`buildAdapterPropertyOverrides()`** — Now accepts the group's NIC list and checks `portConfig[i].rdmaManual` — if any NIC in the group had its RDMA manually changed at Step 07, the override flag is set (safety net)
3. **Call site updated** — Passes `g.nics` to the updated function signature

### Version

Bumped `0.18.01` → `0.18.02` with release notes updated in README.md, CHANGELOG.md, and js/changelog.js (What's New modal).

### Testing

All 494 existing tests pass. Manual verification: create a switchless 4+ NIC config, disable RDMA on Mgmt+Compute NICs, confirm JSON now shows `overrideAdapterProperty: true` for the MgmtCompute intent.