### PR TITLE
Fix Custom Location Name not updating in ARM parameters (fixes #189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.18.03] - 2026-03-30
+
+### Fixed
+
+#### ARM Parameters: Fix Custom Location Name (fixes #189)
+- **Fix `customLocation` parameter key**: Fixed a bug where the "Custom Location Name" input field on the ARM Parameters page was not updating the `customLocation` value in the generated parameter JSON — the update code referenced a mismatched key (`customLocationName` instead of `customLocation`)
+- **Pre-population fix**: The custom location input field also now correctly pre-populates from the parameter JSON when loading a template
+
+---
+
 ## [0.18.02] - 2026-03-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Odin for Azure Local
 
-## Version 0.18.02 - Available here: https://aka.ms/ODIN-for-AzureLocal
+## Version 0.18.03 - Available here: https://aka.ms/ODIN-for-AzureLocal
 
 A comprehensive web-based wizard to help design and configure Azure Local (formerly Azure Stack HCI) architectures. This tool guides users through deployment scenarios, network topology decisions, security configuration, and generates ARM parameters for deployment with automated deployment scripts. The Sizer Tool (preview) can be used to provide example cluster hardware configurations, based on your workload scenarios and capacity requirements.
 
@@ -40,8 +40,8 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 - **Visual Feedback**: Architecture diagrams and network topology visualizations
 - **ARM Parameters Generation**: Export Azure Resource Manager parameters JSON
 
-### 🎉 Version 0.18.02 - Latest Release
-- **Designer: Fix NIC `overrideAdapterProperty` ([#187](https://github.com/Azure/odinforazurelocal/issues/187))**: Fixed a bug where disabling RDMA on NICs assigned to the Management+Compute intent (e.g., in a switchless 4+ NIC configuration) would generate `"overrideAdapterProperty": false` in the ARM parameter JSON instead of `true` — the override flag now correctly activates when NIC-level RDMA is changed at Step 07 or auto-disabled at Step 08
+### 🎉 Version 0.18.03 - Latest Release
+- **ARM Parameters: Fix Custom Location Name ([#189](https://github.com/Azure/odinforazurelocal/issues/189))**: Fixed a bug where the "Custom Location Name" input field on the ARM Parameters page was not updating the `customLocation` value in the generated parameter JSON — the update code referenced a mismatched key (`customLocationName` instead of `customLocation`)
 
 > **Full Version History**: See [Appendix A - Version History](#appendix-a---version-history) for complete release notes.
 
@@ -329,7 +329,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.18.01  
+**Version**: 0.18.03  
 **Last Updated**: March 2026  
 **Compatibility**: Azure Local 2506+
 
@@ -344,6 +344,9 @@ For questions, feedback, or support, please visit the [GitHub repository](https:
 For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.18.x Series (March 2026)
+
+#### 0.18.03 - ARM Parameters: Fix Custom Location Name (#189)
+- **Fix Custom Location Name ([#189](https://github.com/Azure/odinforazurelocal/issues/189))**: Fixed a bug where the "Custom Location Name" input field on the ARM Parameters page was not updating the `customLocation` value in the generated parameter JSON — the update code referenced a mismatched key (`customLocationName` instead of `customLocation`)
 
 #### 0.18.02 - Designer: Fix NIC overrideAdapterProperty (#187)
 - **Fix NIC `overrideAdapterProperty` ([#187](https://github.com/Azure/odinforazurelocal/issues/187))**: Fixed a bug where disabling RDMA on NICs assigned to the Management+Compute intent (e.g., in a switchless 4+ NIC configuration) would generate `"overrideAdapterProperty": false` in the ARM parameter JSON instead of `true`

--- a/arm/arm.js
+++ b/arm/arm.js
@@ -318,8 +318,8 @@
         }
         
         var customLocationInput = document.getElementById('input-custom-location');
-        if (customLocationInput && params.customLocationName && isValidValue(params.customLocationName.value)) {
-            customLocationInput.value = params.customLocationName.value;
+        if (customLocationInput && params.customLocation && isValidValue(params.customLocation.value)) {
+            customLocationInput.value = params.customLocation.value;
         }
     }
 
@@ -926,8 +926,8 @@ function updateParameters() {
         params.adouPath.value = ouPath;
     }
     
-    if (customLocation && params.customLocationName) {
-        params.customLocationName.value = customLocation;
+    if (customLocation && params.customLocation) {
+        params.customLocation.value = customLocation;
     }
     
     // Also update any remaining REPLACE_WITH_ placeholders with generic replacements

--- a/index.html
+++ b/index.html
@@ -505,7 +505,7 @@
                 <div class="header-logo-wrapper">
                     <img id="odin-logo" src="images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.18.02 | <button type="button" onclick="showChangelog();" class="whats-new-link">What's New</button>
+                        Version 0.18.03 | <button type="button" onclick="showChangelog();" class="whats-new-link">What's New</button>
                     </div>
                 </div>
             </div>

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -53,12 +53,23 @@ function showChangelog() { // eslint-disable-line no-unused-vars
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
-                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.18.02</h4>
-                    <div style="font-size: 13px; color: var(--text-secondary);">March 26, 2026</div>
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.18.03</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">March 30, 2026</div>
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
-                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 Designer: Fix NIC overrideAdapterProperty (fixes <a href="https://github.com/Azure/odinforazurelocal/issues/187" target="_blank">#187</a>)</h4>
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔧 ARM Parameters: Fix Custom Location Name (fixes <a href="https://github.com/Azure/odinforazurelocal/issues/189" target="_blank">#189</a>)</h4>
+                    <ul style="margin: 0; padding-left: 20px;">
+                        <li><strong>Fix customLocation parameter key:</strong> Fixed a bug where the "Custom Location Name" input field on the ARM Parameters page was not updating the <code>customLocation</code> value in the generated parameter JSON — the update code referenced a mismatched key (<code>customLocationName</code> instead of <code>customLocation</code>).</li>
+                        <li><strong>Pre-population fix:</strong> The custom location input field also now correctly pre-populates from the parameter JSON when loading a template.</li>
+                    </ul>
+                </div>
+
+                <hr style="border: none; border-top: 2px solid var(--glass-border); margin: 24px 0;">
+                <div style="font-size: 12px; color: var(--text-secondary); margin-bottom: 16px;">Previous: Version 0.18.02</div>
+
+                <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
+                    <h4 style="color: var(--text-secondary); margin: 0 0 12px 0;">🔧 Designer: Fix NIC overrideAdapterProperty (fixes <a href="https://github.com/Azure/odinforazurelocal/issues/187" target="_blank">#187</a>)</h4>
                     <ul style="margin: 0; padding-left: 20px;">
                         <li><strong>Fix overrideAdapterProperty:</strong> Fixed a bug where disabling RDMA on NICs assigned to the Management+Compute intent (e.g., in a switchless 4+ NIC configuration) would generate <code>"overrideAdapterProperty": false</code> in the ARM parameter JSON instead of <code>true</code>.</li>
                         <li><strong>NIC-Level RDMA Detection:</strong> The ARM intent generator now detects NIC-level RDMA changes made at Step 07 (Port Configuration) and correctly sets the override flag.</li>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -34,7 +34,7 @@
                 <div class="header-logo-wrapper">
                     <img src="../images/odin-logo.png" alt="Odin for Azure Local Logo">
                     <div class="header-version">
-                        Version 0.18.02 | <button type="button" onclick="showChangelog();" class="whats-new-link">What's New</button>
+                        Version 0.18.03 | <button type="button" onclick="showChangelog();" class="whats-new-link">What's New</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
Fixes #189 — The **Custom Location Name** input field on the ARM Parameters page was not updating the `customLocation` value in the generated parameter JSON when clicking **Update Parameter JSON**.

## Root Cause
The `updateParameters()` function in `arm/arm.js` referenced `params.customLocationName`, but the actual parameter key generated by the Designer (in `js/script.js`) is `params.customLocation`. This key mismatch caused the condition to always evaluate as falsy, silently skipping the update.

The same mismatch existed in the pre-population code path (loading existing values from the JSON back into the input field).

## Changes
- **`arm/arm.js`**: Changed `params.customLocationName` → `params.customLocation` in both the `updateParameters()` function (line ~929) and the input pre-population code (line ~321)
- **Version bump**: 0.18.02 → 0.18.03 in `README.md`, `index.html`, `sizer/index.html`, `CHANGELOG.md`, `js/changelog.js`