### PR TITLE
Code-quality hardening follow-ups (0.20.06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sizer/sizer.js` — removed unused `clusterTypeGpu` local in the GPU capacity notes block.
   - `sizer/rack3d.js` — removed the unused `makeCable()` helper (dead code — the actual cable routing uses explicit `LineCurve3` segments inline).
   - `report/report.js` — removed unused `startX` local in `renderCustomAdaptersHorizontal()` (a separate `groupedStartX` is used for the actual layout).
+- **FQDN validator — RFC length limits** (`js/disconnected.js`): `isValidFqdn()` now enforces the RFC 1035/1123 practical DNS limits (total FQDN ≤ 253 characters, each label ≤ 63 characters) in addition to the regex check, and trims whitespace before validating.
+- **Subnet mask inline comment** (`js/disconnected.js`): Added an inline explanatory comment next to the `(~0 << (32 - prefix)) >>> 0` bitwise expression so the mask construction is self-documenting.
+- **SVG export retry logging** (`scripts/svg-export-common.js`): The first-attempt failure is now logged with the error message before the retry, aiding diagnosis of intermittent draw.io CLI crashes.
+- **Loop-variable style consistency** (`sizer/rack3d.js`): Normalised a lone `let u` loop declaration to `var u` to match the surrounding `var`-based style in the file.
+- **QoS Validator structured error logging** (`switch-config/qos-audit.js`): `resolveAutoProfile()` now logs the caught error as a `{ message, stack }` object instead of the raw `Error` object for better browser-devtools readability.
+- **Walkthrough demo — dynamic template index** (`tools/demos/odin-full-walkthrough.spec.js`): The "8-Node Rack Aware" template is now located by text and its `loadTemplate(N)` index extracted from the card's `onclick`, rather than relying on a hardcoded index of 3. The demo fails fast with a clear error if the template is not present.
 
 ### Fixed
 

--- a/js/disconnected.js
+++ b/js/disconnected.js
@@ -110,9 +110,16 @@ const FQDN_VALIDATION_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z
     // Helper: check if the current FQDN value is a valid format
     function isValidFqdn(fqdn) {
         if (!fqdn) return false;
-        if (!FQDN_VALIDATION_REGEX.test(fqdn)) return false;
+        const normalizedFqdn = fqdn.trim();
 
-        const labels = fqdn.toLowerCase().split('.');
+        // RFC 1035/1123 practical DNS limits:
+        // - Entire FQDN must be <= 253 characters (without trailing dot).
+        // - Each label must be <= 63 characters.
+        if (normalizedFqdn.length > 253) return false;
+        if (!FQDN_VALIDATION_REGEX.test(normalizedFqdn)) return false;
+
+        const labels = normalizedFqdn.toLowerCase().split('.');
+        if (labels.some(function(label) { return label.length > 63; })) return false;
 
         // Reject apex/root domains like contoso.com (must be a host FQDN)
         if (labels.length < 3) return false;
@@ -358,7 +365,7 @@ const FQDN_VALIDATION_REGEX = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z
         if (prefix === 0) return 0;
         // Start from all 1s, shift left to create leading 1s followed by trailing 0s,
         // then coerce to unsigned 32-bit integer.
-        return (~0 << (32 - prefix)) >>> 0;
+        return (~0 << (32 - prefix)) >>> 0; // Mask with `prefix` leading 1s followed by trailing 0s.
     }
 
     function validateApplianceIps(ip1, ip2, requireInfraSubnet) {

--- a/scripts/svg-export-common.js
+++ b/scripts/svg-export-common.js
@@ -85,6 +85,8 @@ function exportDiagrams(fileFilter, label) {
             execFileSync(exePath, drawioArgs, { stdio: 'pipe', timeout: 60000, shell: false });
         } catch (e) {
             // draw.io CLI sometimes crashes but still writes the file; retry once
+            const firstError = e && e.message ? e.message : String(e);
+            console.warn('  First export attempt failed for ' + drawioFile + ': ' + firstError);
             console.log('  Retry...');
             execFileSync(exePath, drawioArgs, { stdio: 'pipe', timeout: 60000, shell: false });
         }

--- a/sizer/rack3d.js
+++ b/sizer/rack3d.js
@@ -168,7 +168,7 @@ function buildRackFrame(scene, offsetX, offsetZ, facing) {
     // U-slot rail markers (thin horizontal lines on front posts)
     var railGeo = new THREE.BoxGeometry(RACK.RAIL_DEPTH, 0.002, RACK.POST_SIZE);
     var baseY = 0.06; // bottom offset inside frame
-    for (let u = 0; u <= RACK.TOTAL_U; u++) {
+    for (var u = 0; u <= RACK.TOTAL_U; u++) {
         var y = baseY + u * RACK.U_HEIGHT;
         [-RACK.WIDTH / 2 + RACK.POST_SIZE + RACK.RAIL_DEPTH / 2,
          RACK.WIDTH / 2 - RACK.POST_SIZE - RACK.RAIL_DEPTH / 2].forEach(function(x) {

--- a/switch-config/qos-audit.js
+++ b/switch-config/qos-audit.js
@@ -897,7 +897,10 @@
             if (ds && (ds.storage === 'switchless' || ds.storage === 'Switchless')) return 'hci_switchless';
             return 'hci_switched';
         } catch (e) {
-            console.warn('QoS audit: failed to resolve auto profile from localStorage, using default profile.', e);
+            console.warn('QoS audit: failed to resolve auto profile from localStorage, using default profile.', {
+                message: e && e.message ? e.message : String(e),
+                stack: e && e.stack ? e.stack : undefined
+            });
             return 'hci_switched';
         }
     }

--- a/tests/index.html
+++ b/tests/index.html
@@ -4056,7 +4056,7 @@
             })(),
             (() => {
                 // Verify the flag reset logic works without calling calculateRequirements
-                _disaggAutoUpgraded = true;
+                let _disaggAutoUpgraded = true;
                 const mapping = _MANUAL_FIELD_TO_FLAG['cluster-type'];
                 // Simulate what clearSingleManualOverride does for the flag
                 switch (mapping.flag) {

--- a/tools/demos/odin-full-walkthrough.spec.js
+++ b/tools/demos/odin-full-walkthrough.spec.js
@@ -192,18 +192,27 @@ test('ODIN full walkthrough - Sizer to Switch Config', async ({ page, context })
     await annotate(page, 'ODIN Designer - deployment wizard & validated architectures');
     await page.waitForTimeout(250);
 
-    // -- 8. Open the template picker and load 8-Node Rack Aware (index 3) --
+    // -- 8. Open the template picker and load 8-Node Rack Aware --
     await annotate(page, 'Load example template - 8-Node Rack Aware');
     await page.getByRole('button', { name: /Load Example Configuration Template/i }).first().click();
     await page.waitForTimeout(350);
     await page.evaluate(() => {
-        const card = Array.from(document.querySelectorAll('div[onclick^="loadTemplate"]'))
-            .find((el) => /8-Node Rack Aware/i.test(el.textContent || ''));
+        const cards = Array.from(document.querySelectorAll('div[onclick^="loadTemplate"]'));
+        const card = cards.find((el) => /8-Node Rack Aware/i.test(el.textContent || ''));
         if (card && card.scrollIntoView) card.scrollIntoView({ block: 'center', behavior: 'smooth' });
     });
     await page.waitForTimeout(500);
     // @ts-ignore - loadTemplate is a global defined in js/script.js
-    await page.evaluate(() => { window.loadTemplate(3); });
+    await page.evaluate(() => {
+        const cards = Array.from(document.querySelectorAll('div[onclick^="loadTemplate"]'));
+        const card = cards.find((el) => /8-Node Rack Aware/i.test(el.textContent || ''));
+        if (!card) throw new Error('Template "8-Node Rack Aware" not found');
+        const onclick = card.getAttribute('onclick') || '';
+        const match = onclick.match(/loadTemplate\((\d+)\)/);
+        if (!match) throw new Error('Unable to determine template index for "8-Node Rack Aware"');
+        const index = Number(match[1]);
+        window.loadTemplate(index);
+    });
     await page.waitForTimeout(600);
 
     // -- 9. Scroll to the bottom to showcase the Generate / Validate button --


### PR DESCRIPTION
## Summary

Addresses the latest batch of 6 GitHub AI scan findings plus a CodeQL missing-declaration fix. Version stays at **0.20.06** — these are internal code-quality and hardening improvements, not user-facing features.

## Findings addressed

1. **[js/disconnected.js](js/disconnected.js) — FQDN RFC length limits**: `isValidFqdn()` now enforces the RFC 1035/1123 practical DNS limits (total FQDN ≤ 253 chars, per-label ≤ 63 chars) in addition to the regex check, and trims whitespace before validating.
2. **[js/disconnected.js](js/disconnected.js) — subnet mask comment**: Added an inline explanatory comment next to the `(~0 << (32 - prefix)) >>> 0` bitwise expression.
3. **[scripts/svg-export-common.js](scripts/svg-export-common.js) — retry diagnostics**: Logs the first-attempt failure message before retrying the draw.io CLI export, aiding intermittent-crash diagnosis. Did **not** add a `SharedArrayBuffer`/`Atomics.wait` sleep as the scanner suggested — it's a local build script, added complexity without real benefit.
4. **[sizer/rack3d.js](sizer/rack3d.js) — loop-variable style consistency**: Normalised a lone `let u` loop declaration to `var u` to match the surrounding file style.
5. **[switch-config/qos-audit.js](switch-config/qos-audit.js) — structured error logging**: `resolveAutoProfile()` now logs the caught error as a `{ message, stack }` object instead of the raw `Error` object for better devtools readability.
6. **[tools/demos/odin-full-walkthrough.spec.js](tools/demos/odin-full-walkthrough.spec.js) — dynamic template index**: The "8-Node Rack Aware" template is now located by text and its `loadTemplate(N)` index extracted from the card's `onclick`, rather than relying on a hardcoded index of 3. Fails fast if the template is not present.
7. **[tests/index.html](tests/index.html) — missing declaration** (previous commit on branch): Declared `_disaggAutoUpgraded` with `let` inside the test IIFE so the test no longer creates an implicit global that collides with `sizer.js`'s real variable.

## Validation
- `npx eslint` → **0 errors**
- `npx html-validate index.html arm/arm.html report/report.html sizer/index.html` → clean
- `node scripts/run-tests.js` → **1030/1030 passed**

CHANGELOG entries folded into the existing `[0.20.06]` section (under *Code Quality & Security Hardening*). No version bump, no user-visible UX changes.
