### PR TITLE
Fix 4-NIC iSCSI shared-path flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-#### Disaggregated Host-Networking Diagrams — Merged SET vSwitch wrapper
-- **NIC3/NIC4 cluster NICs are now wrapped in a single dashed group** when a SET vSwitch is present (`ClusterISCSISwitch` for iSCSI 4-NIC, `ClusterBackupSwitch` for iSCSI 6-NIC + backup), mirroring how Mgmt + Compute already wraps OCP-NIC1 + OCP-NIC2. Replaces the previous layout of two separate dashed boxes inside an outer SET overlay rectangle. Applied to both the wizard preview (`js/disaggregated.js`) and the configuration report's 2-node view (`report/report.js`).
-- **vNIC card layout — 3-line rendering** (primary identifier / literal `vNIC` / VLAN). vNIC card height bumped 30 → 42 px and a regex split parses ` vNIC` suffix from labels (`Cluster1 vNIC`, `iSCSI1 vNIC`, …). SET label and Backup VLAN trunk badge moved below the wrapper to eliminate border/label overlap.
-- **`WorkloadSwitch` → `ClusterISCSISwitch`** rename across explanations (DA1, DA8), warnings (DA2), port-count descriptions (DA4), cluster route descriptions, and the rendered SET label inside the diagrams.
+#### Disaggregated Host-Networking Diagrams — 4-NIC iSCSI physical paths
+- **iSCSI 4-NIC now renders NIC3/NIC4 as standalone physical shared paths** in the wizard preview and configuration report: NIC3 carries Cluster A + iSCSI Path A, and NIC4 carries Cluster B + iSCSI Path B. There is no `ClusterISCSISwitch`, no host vNIC layer, and no SET wrapper for this layout.
+- **6-NIC + Backup still uses `ClusterBackupSwitch` only for Cluster/Backup** on NIC3/NIC4. Dedicated iSCSI remains on NIC5/NIC6 and no longer gets misclassified as sharing cluster ports.
+- **vNIC card layout — 3-line rendering** (primary identifier / literal `vNIC` / VLAN) remains for layouts that genuinely have host vNICs, such as Management + Compute and 6-NIC + Backup Cluster vNICs.
 
-#### Disaggregated Overrides — iSCSI A/B subnet inputs
-- **Show iSCSI A/B VLAN + Subnet inputs for all iSCSI scenarios** (`js/disaggregated.js` `renderDisaggOverrides` + `confirmDisaggOverrides`). Previously gated to `iscsi_6nic && !backup` only — now also shown for `iscsi_4nic` (where NIC3/NIC4 host `iSCSI1`/`iSCSI2` vNICs in `ClusterISCSISwitch`) and `iscsi_6nic + backup` (NIC5/NIC6 still standalone). Card subtitle adapts to the transport: `(SET vNIC — ClusterISCSISwitch)` vs `(Standalone)`.
-- **Pre-populated iSCSI A/B defaults** (`10.50.1.0/24` and `10.60.1.0/24`) seeded into the initial `state.disaggSubnets` and the reset path in `js/script.js`, so users can confirm immediately or edit before confirming — same behaviour as Cluster 1/2 subnets.
+#### Disaggregated Overrides — shared vs dedicated iSCSI
+- **4-NIC iSCSI derives from the Cluster A/B VLAN/subnet inputs** instead of showing separate iSCSI A/B override cards. The wizard now explains that target portal `/32` routes must be pinned to physical NIC3/NIC4.
+- **Dedicated iSCSI A/B VLAN + Subnet inputs are shown for iSCSI 6-NIC**, including the 6-NIC + Backup layout where NIC5/NIC6 stay standalone. Defaults are now VLAN `300` / `400` and subnets `10.30.30.0/24` / `10.40.40.0/24`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ A comprehensive web-based wizard to help design and configure Azure Local (forme
 
 
 ### 🎉 Version 0.20.08 - Latest Release
-- **Disaggregated Host Networking — Merged SET vSwitch wrapper for Cluster NICs**: When NIC3/NIC4 carry a SET vSwitch (iSCSI 4-NIC `ClusterISCSISwitch`, or iSCSI 6-NIC + Backup `ClusterBackupSwitch`), the two cluster NICs are now wrapped in a single dashed group (matching how Mgmt + Compute already wraps OCP-NIC1 + OCP-NIC2), instead of two separate dashed boxes inside an outer overlay. Applies to both the wizard preview (`js/disaggregated.js`) and the configuration report's 2-node host-networking diagram (`report/report.js`).
-- **Disaggregated vNIC labels — readability**: Cluster/iSCSI host vNICs (e.g. `Cluster1 vNIC`, `iSCSI1 vNIC`) now render across 3 lines (name / `vNIC` / VLAN) so neighbouring cards no longer overlap. vNIC card height bumped 30 → 42 px. SET label moved below the wrapper to eliminate the previous label/border overlap.
-- **Disaggregated Overrides — iSCSI A/B subnets shown for all iSCSI scenarios**: The `iSCSI Network A` and `iSCSI Network B` VLAN + Subnet inputs are now shown for **iscsi_4nic** and **iscsi_6nic + backup** (previously only iscsi_6nic without backup), with the card subtitle adapting to the transport (`SET vNIC — ClusterISCSISwitch` vs `Standalone`). Confirm-overrides validation extended to require iSCSI A/B for the same broader set.
-- **Disaggregated Overrides — pre-populated iSCSI subnets**: Default iSCSI A `10.50.1.0/24` and iSCSI B `10.60.1.0/24` are seeded into initial state so users can confirm immediately or edit before confirming, matching how Cluster 1/2 already work.
-- **Naming consistency**: `WorkloadSwitch` renamed to `ClusterISCSISwitch` across explanations, warnings, port-count descriptions, route descriptions, and rendered SET labels for clarity vs `ClusterBackupSwitch`.
+- **Disaggregated Host Networking — iSCSI 4-NIC physical shared paths**: NIC3/NIC4 now render as standalone physical adapters. NIC3 carries Cluster A + iSCSI Path A, and NIC4 carries Cluster B + iSCSI Path B, using the same VLAN/subnet/source IP with no SET, no vSwitch, and no host vNICs. Applies to both the wizard preview (`js/disaggregated.js`) and the configuration report's 2-node host-networking diagram (`report/report.js`).
+- **Disaggregated Host Networking — 6-NIC + Backup correction**: `ClusterBackupSwitch` remains only for Cluster/Backup on NIC3/NIC4; dedicated iSCSI remains on NIC5/NIC6 and is no longer treated as sharing cluster ports.
+- **Disaggregated Overrides — shared vs dedicated iSCSI**: 4-NIC iSCSI now derives from the Cluster A/B VLAN/subnet inputs. Separate iSCSI Network A/B override cards are shown only for **iscsi_6nic**, including 6-NIC + Backup.
+- **Disaggregated Overrides — iSCSI defaults**: Dedicated iSCSI A/B defaults are now VLAN `300` / `400` with subnets `10.30.30.0/24` / `10.40.40.0/24`.
+- **Disaggregated vNIC labels — readability**: 3-line vNIC labels remain for layouts that genuinely have host vNICs, such as Management + Compute and 6-NIC + Backup Cluster vNICs.
 
 > **Full Version History**: See [Appendix A - Version History](#appendix-a---version-history) for complete release notes.
 
@@ -370,12 +370,12 @@ For detailed changelog information, see [CHANGELOG.md](CHANGELOG.md).
 
 ### 🎉 Version 0.20.x Series (April 2026)
 
-#### 0.20.08 - Disaggregated: Merged SET wrapper, iSCSI subnet overrides
-- **Merged SET vSwitch wrapper for Cluster NICs** in host-networking diagrams (wizard preview + report 2-node view): NIC3/NIC4 in `ClusterISCSISwitch` (iSCSI 4-NIC) or `ClusterBackupSwitch` (iSCSI 6-NIC + backup) are now wrapped in a single dashed group, mirroring how Mgmt + Compute already wraps OCP-NIC1 + OCP-NIC2.
-- **vNIC label readability**: 3-line vNIC cards (name / `vNIC` / VLAN), card height 30 → 42 px, SET label moved below the wrapper to remove border overlap.
-- **iSCSI A/B Subnet + VLAN inputs shown for all iSCSI scenarios** in DA8 → Overrides (previously only for `iscsi_6nic` without backup). Card subtitle adapts to the transport (`SET vNIC — ClusterISCSISwitch` vs `Standalone`). Confirm-overrides validation extended.
-- **Pre-populated iSCSI subnet defaults** (`10.50.1.0/24` / `10.60.1.0/24`) seeded into initial state so users can confirm immediately or edit, matching the Cluster 1/2 behaviour.
-- **`WorkloadSwitch` → `ClusterISCSISwitch`** rename across explanations, warnings, port-count descriptions, route descriptions, and rendered SET labels.
+#### 0.20.08 - Disaggregated: iSCSI 4-NIC physical paths
+- **iSCSI 4-NIC physical shared paths** in host-networking diagrams (wizard preview + report 2-node view): NIC3/NIC4 stay standalone physical adapters carrying Cluster A/B and iSCSI Path A/B with no SET, no vSwitch, and no host vNICs.
+- **6-NIC + Backup correction**: `ClusterBackupSwitch` remains only for Cluster/Backup on NIC3/NIC4; dedicated iSCSI remains on NIC5/NIC6.
+- **Shared vs dedicated iSCSI overrides**: 4-NIC iSCSI derives from Cluster A/B VLAN/subnet values. Dedicated iSCSI A/B override cards appear only for `iscsi_6nic`, including 6-NIC + Backup.
+- **Dedicated iSCSI defaults** updated to VLAN `300` / `400` and subnets `10.30.30.0/24` / `10.40.40.0/24`.
+- **vNIC label readability** remains for layouts that genuinely render host vNICs, such as Management + Compute and 6-NIC + Backup Cluster vNICs.
 
 #### 0.20.07 - Knowledge Tab: Context-Aware Help Button
 - **Knowledge Help button**: The nav-bar Help button on the Knowledge tab now shows a dedicated walkthrough for whichever sidebar topic is active — the **Outbound Connectivity Architecture Guide** (same-origin written reference) or **AzLoFlows** (external interactive diagram builder). Previously it fell through to the Designer onboarding because the original same-origin flow-diagram pages were replaced by AzLoFlows and the cross-origin `contentWindow.showFlowOnboarding()` probe in `nav.js` could no longer reach the embedded page.

--- a/index.html
+++ b/index.html
@@ -864,7 +864,6 @@
                             <p>Dedicated FC HBAs on separate fabric. FC traffic is isolated from Ethernet leaf switches.</p>
                         </div>
                         <div class="option-card" data-value="iscsi_4nic" onclick="selectDisaggOption('storageType', 'iscsi_4nic')">
-                            <span class="coming-soon-badge">Coming Soon</span>
                             <div class="icon">
                                 <svg aria-hidden="true" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                                     <rect x="3" y="3" width="18" height="18" rx="2" stroke-width="1.5" />
@@ -872,8 +871,7 @@
                                 </svg>
                             </div>
                             <h3>iSCSI SAN (4-NIC)</h3>
-                            <p>iSCSI shares PCIe1 with CSV/LM via trunk. 4 NICs total per machine.</p>
-                            <p class="preview-note">⚠️ Feature not available yet</p>
+                            <p>NIC3/NIC4 stay physical: Cluster A/B and iSCSI Path A/B share the same adapters, VLANs, subnets, and source IPs. No SET or host vNICs.</p>
                         </div>
                         <div class="option-card" data-value="iscsi_6nic" onclick="selectDisaggOption('storageType', 'iscsi_6nic')">
                             <span class="coming-soon-badge">Coming Soon</span>
@@ -996,7 +994,7 @@
                     </div>
                     <div style="margin-bottom: 12px; padding: 10px 14px; border-radius: 8px; background: rgba(139, 92, 246, 0.08); border: 1px solid rgba(139, 92, 246, 0.35); color: var(--text-secondary); font-size: 0.85rem; line-height: 1.5;">
                         <strong style="color: var(--accent-purple);">Tip — Access-mode VLANs are switch-only</strong><br>
-                        The VLAN IDs below (Management, Cluster A/B, iSCSI A/B, Backup) are configured on the physical leaf switch ports in <strong>Access Mode</strong> by default. The leaf adds/strips the 802.1Q tag — the host NICs receive <em>untagged</em> frames on these networks. That means on DA8 <strong>Network Adapter Ports → Overrides</strong>, the Cluster VLAN boxes are shown as <code>0</code> (untagged) and are read-only by design. Toggling the Cluster A/B drop-downs to <strong>Trunk</strong> flips both (they are paired) — the host NIC then tags and the VLAN value is emitted to the ARM <code>sanNetworkList.clusterNetworkConfig.adapterIPConfig[*].vlanId</code> parameter. Tenant LNET VLANs remain trunked to the host regardless.
+                        The VLAN IDs below (Management, Cluster A/B, dedicated iSCSI A/B for 6-NIC, Backup) are configured on the physical leaf switch ports in <strong>Access Mode</strong> by default. In the 4-NIC iSCSI layout, iSCSI Path A/B derives from the Cluster A/B VLANs on NIC3/NIC4. The leaf adds/strips the 802.1Q tag — the host NICs receive <em>untagged</em> frames on these networks. That means on DA8 <strong>Network Adapter Ports → Overrides</strong>, the Cluster VLAN boxes are shown as <code>0</code> (untagged) and are read-only by design. Toggling the Cluster A/B drop-downs to <strong>Trunk</strong> flips both (they are paired) — the host NIC then tags and the VLAN value is emitted to the ARM <code>sanNetworkList.clusterNetworkConfig.adapterIPConfig[*].vlanId</code> parameter. Tenant LNET VLANs remain trunked to the host regardless.
                     </div>
                     <div id="da4-vlan-grid" style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 12px;">
                         <!-- Dynamically populated by disaggregated.js -->
@@ -1230,7 +1228,7 @@
                     <div id="da8-intent-section" style="margin-top: 2rem;">
                         <h4 style="margin: 0 0 4px 0;">Network Traffic Intents</h4>
                         <p style="margin: 0 0 16px 0; color: var(--text-secondary); font-size: 0.9rem;">
-                            Drag and drop network adapters to assign them to traffic intents. In disaggregated mode, only the Management + Compute intent uses SET teaming. Cluster, iSCSI, and Backup NICs are standalone (one-to-one VLAN mapping).
+                            Drag and drop network adapters to assign them to traffic intents. In disaggregated mode, Management + Compute uses SET teaming. 4-NIC iSCSI keeps NIC3/NIC4 standalone as shared Cluster+iSCSI paths, while 6-NIC + Backup uses ClusterBackupSwitch on NIC3/NIC4 and leaves iSCSI on dedicated NIC5/NIC6.
                         </p>
 
                         <div id="da8-adapter-mapping-container" class="adapter-mapping">

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -58,13 +58,13 @@ function showChangelog() { // eslint-disable-line no-unused-vars
                 </div>
 
                 <div style="margin-bottom: 24px; padding-bottom: 24px; border-bottom: 1px solid var(--glass-border);">
-                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔌 Disaggregated — Merged SET wrapper & iSCSI subnet overrides</h4>
+                    <h4 style="color: var(--accent-purple); margin: 0 0 12px 0;">🔌 Disaggregated — iSCSI 4-NIC physical paths</h4>
                     <ul style="margin: 0; padding-left: 20px;">
-                        <li><strong>Merged SET vSwitch wrapper for Cluster NICs</strong> in host-networking diagrams (wizard preview + report 2-node view): NIC3/NIC4 in <code>ClusterISCSISwitch</code> (iSCSI 4-NIC) or <code>ClusterBackupSwitch</code> (iSCSI 6-NIC + backup) are now wrapped in a single dashed group, matching how Mgmt + Compute already wraps OCP-NIC1 + OCP-NIC2.</li>
-                        <li><strong>vNIC label readability:</strong> 3-line vNIC cards (name / <code>vNIC</code> / VLAN), card height 30 → 42 px, SET label moved below the wrapper to eliminate border overlap.</li>
-                        <li><strong>iSCSI A/B Subnet + VLAN inputs shown for all iSCSI scenarios</strong> in DA8 → Overrides (previously only <code>iscsi_6nic</code> without backup). Card subtitle adapts to the transport (<code>SET vNIC — ClusterISCSISwitch</code> vs <code>Standalone</code>); confirm-overrides validation extended.</li>
-                        <li><strong>Pre-populated iSCSI subnet defaults</strong> (<code>10.50.1.0/24</code> / <code>10.60.1.0/24</code>) seeded into initial state so users can confirm immediately or edit, matching the Cluster 1/2 behaviour.</li>
-                        <li><strong><code>WorkloadSwitch</code> → <code>ClusterISCSISwitch</code></strong> rename across explanations, warnings, port-count descriptions, route descriptions, and rendered SET labels.</li>
+                        <li><strong>iSCSI 4-NIC now uses physical shared paths</strong>: NIC3 carries Cluster A + iSCSI Path A, and NIC4 carries Cluster B + iSCSI Path B. No <code>ClusterISCSISwitch</code>, no SET, and no host vNICs are rendered for this layout.</li>
+                        <li><strong>6-NIC + Backup stays dedicated for iSCSI</strong>: <code>ClusterBackupSwitch</code> remains only for Cluster/Backup on NIC3/NIC4, while iSCSI remains on NIC5/NIC6.</li>
+                        <li><strong>Shared vs dedicated iSCSI overrides</strong>: 4-NIC iSCSI derives from Cluster A/B VLAN/subnet values. Dedicated iSCSI A/B override cards appear only for <code>iscsi_6nic</code>.</li>
+                        <li><strong>Dedicated iSCSI defaults</strong> updated to VLAN <code>300</code> / <code>400</code> and subnets <code>10.30.30.0/24</code> / <code>10.40.40.0/24</code>.</li>
+                        <li><strong>vNIC label readability</strong> remains for layouts that genuinely render host vNICs, such as Management + Compute and 6-NIC + Backup Cluster vNICs.</li>
                     </ul>
                 </div>
 

--- a/js/disaggregated.js
+++ b/js/disaggregated.js
@@ -26,7 +26,8 @@ function getMaxNodesPerRack(storageType, backupEnabled) {
 }
 
 // Apply/remove disabled styling on the DA2 "Enable Backup Network" card based on
-// the currently-selected storage type. Spec §4: backup is not supported on iSCSI 4-NIC.
+// the currently-selected storage type. Backup is not supported on iSCSI 4-NIC because
+// NIC3/NIC4 stay as standalone physical Cluster+iSCSI paths with no vSwitch layer.
 function updateDisaggBackupCardState() {
     const card = document.querySelector('#step-da2 .option-card[data-value="true"]');
     if (!card) return;
@@ -77,7 +78,7 @@ function selectDisaggOption(category, value) {
         if (exp) {
             const explanations = {
                 fc_san: '<strong style="color: var(--accent-purple);">Fibre Channel SAN</strong> — Dedicated FC HBAs connect to separate FC switches. Storage traffic is completely isolated from the Ethernet leaf-spine fabric. Max 16 nodes per rack.',
-                iscsi_4nic: '<strong style="color: var(--accent-purple);">iSCSI SAN (4-NIC)</strong> — NIC3/NIC4 are wrapped in a customer-managed SET vSwitch (<code>ClusterISCSISwitch</code>, outside ATC) hosting four host vNICs: <code>Cluster1 vNIC</code>, <code>Cluster2 vNIC</code>, <code>iSCSI1 vNIC</code>, <code>iSCSI2 vNIC</code>. Backup network is <strong>not supported</strong> on this layout. Max 16 nodes per rack.',
+                iscsi_4nic: '<strong style="color: var(--accent-purple);">iSCSI SAN (4-NIC)</strong> — NIC3/NIC4 stay as standalone physical adapters. NIC3 carries Cluster A + iSCSI Path A; NIC4 carries Cluster B + iSCSI Path B, using the same VLAN, subnet, source IP, MTU 9014, and per-target /32 routes. No SET vSwitch, no host vNICs, and no ATC intent on NIC3/NIC4. Backup network is <strong>not supported</strong> on this layout. Max 16 nodes per rack.',
                 iscsi_6nic: '<strong style="color: var(--accent-purple);">iSCSI SAN (6-NIC)</strong> — NIC5/NIC6 are dedicated standalone iSCSI Path A/B (no SET, no host vNIC). When backup is enabled, NIC3/NIC4 are wrapped in a customer-managed SET (<code>ClusterBackupSwitch</code>, outside ATC) hosting <code>Cluster1 vNIC</code>/<code>Cluster2 vNIC</code> host vNICs plus a tenant Backup VLAN trunk; iSCSI on NIC5/NIC6 is unchanged. Max 16 nodes per rack.'
             };
             exp.innerHTML = explanations[value] || '';
@@ -92,12 +93,12 @@ function selectDisaggOption(category, value) {
         renderDisaggNicConfig();
 
     } else if (category === 'backup') {
-        // Spec §4: backup network is NOT supported on the iSCSI 4-NIC layout.
+        // Backup network is NOT supported on the iSCSI 4-NIC layout.
         // The card is greyed out via updateDisaggBackupCardState(), but guard the handler too.
         if (value === true && state.disaggStorageType === 'iscsi_4nic') {
             const warning = document.getElementById('da2-warning');
             if (warning) {
-                warning.innerHTML = '<strong style="color: var(--error, #ef4444);">&#9888; Backup not supported on iSCSI 4-NIC</strong><p>The 4-NIC layout shares NIC3/NIC4 between Cluster and iSCSI traffic via a customer-managed <code>ClusterISCSISwitch</code> SET. There is no headroom for an additional tenant Backup VLAN without compromising iSCSI isolation. To enable backup, switch the storage type on <strong>DA1</strong> to <strong>iSCSI SAN (6-NIC)</strong> (or <strong>Fibre Channel SAN</strong>).</p>';
+                warning.innerHTML = '<strong style="color: var(--error, #ef4444);">&#9888; Backup not supported on iSCSI 4-NIC</strong><p>The 4-NIC layout keeps NIC3/NIC4 as standalone physical Cluster+iSCSI paths. It intentionally has no Hyper-V vSwitch or host vNIC layer where a tenant Backup VLAN could be trunked. To enable backup, switch the storage type on <strong>DA1</strong> to <strong>iSCSI SAN (6-NIC)</strong> (or <strong>Fibre Channel SAN</strong>).</p>';
                 warning.classList.remove('hidden');
             }
             // Force-select the "No Backup" card so state stays consistent.
@@ -208,7 +209,7 @@ function restoreDisaggregatedUI() {
         if (exp1) {
             const explanations = {
                 fc_san: '<strong style="color: var(--accent-purple);">Fibre Channel SAN</strong> — Dedicated FC HBAs connect to separate FC switches. Storage traffic is completely isolated from the Ethernet leaf-spine fabric. Max 16 nodes per rack.',
-                iscsi_4nic: '<strong style="color: var(--accent-purple);">iSCSI SAN (4-NIC)</strong> — NIC3/NIC4 are wrapped in a customer-managed SET vSwitch (<code>ClusterISCSISwitch</code>, outside ATC) hosting four host vNICs: <code>Cluster1 vNIC</code>, <code>Cluster2 vNIC</code>, <code>iSCSI1 vNIC</code>, <code>iSCSI2 vNIC</code>. Backup network is <strong>not supported</strong> on this layout. Max 16 nodes per rack.',
+                iscsi_4nic: '<strong style="color: var(--accent-purple);">iSCSI SAN (4-NIC)</strong> — NIC3/NIC4 stay as standalone physical adapters. NIC3 carries Cluster A + iSCSI Path A; NIC4 carries Cluster B + iSCSI Path B, using the same VLAN, subnet, source IP, MTU 9014, and per-target /32 routes. No SET vSwitch, no host vNICs, and no ATC intent on NIC3/NIC4. Backup network is <strong>not supported</strong> on this layout. Max 16 nodes per rack.',
                 iscsi_6nic: '<strong style="color: var(--accent-purple);">iSCSI SAN (6-NIC)</strong> — NIC5/NIC6 are dedicated standalone iSCSI Path A/B (no SET, no host vNIC). When backup is enabled, NIC3/NIC4 are wrapped in a customer-managed SET (<code>ClusterBackupSwitch</code>, outside ATC) hosting <code>Cluster1 vNIC</code>/<code>Cluster2 vNIC</code> host vNICs plus a tenant Backup VLAN trunk; iSCSI on NIC5/NIC6 is unchanged. Max 16 nodes per rack.'
             };
             exp1.innerHTML = explanations[state.disaggStorageType] || '';
@@ -298,7 +299,7 @@ function renderVlanGrid() {
         { key: 'cluster2', label: 'Cluster (CSV/LM) B', vlan: vlans.cluster2, vni: vnis.cluster2, mode: cluster2Mode, modeToggle: 'cluster', netName: clusterNames.cluster2 }
     ];
 
-    if (state.disaggStorageType === 'iscsi_4nic' || state.disaggStorageType === 'iscsi_6nic') {
+    if (state.disaggStorageType === 'iscsi_6nic') {
         rows.push({ key: 'iscsiA', label: 'iSCSI Fabric A', vlan: vlans.iscsiA, vni: vnis.iscsiA, mode: 'Access' });
         rows.push({ key: 'iscsiB', label: 'iSCSI Fabric B', vlan: vlans.iscsiB, vni: vnis.iscsiB, mode: 'Access' });
     }
@@ -694,8 +695,8 @@ function confirmDisaggVlanConfig() {
     if (!vlans.mgmt) missing.push('Management VLAN');
     if (!vlans.cluster1) missing.push('Cluster A VLAN');
     if (!vlans.cluster2) missing.push('Cluster B VLAN');
-    if ((state.disaggStorageType === 'iscsi_4nic' || state.disaggStorageType === 'iscsi_6nic') && !vlans.iscsiA) missing.push('iSCSI A VLAN');
-    if ((state.disaggStorageType === 'iscsi_4nic' || state.disaggStorageType === 'iscsi_6nic') && !vlans.iscsiB) missing.push('iSCSI B VLAN');
+    if (state.disaggStorageType === 'iscsi_6nic' && !vlans.iscsiA) missing.push('iSCSI A VLAN');
+    if (state.disaggStorageType === 'iscsi_6nic' && !vlans.iscsiB) missing.push('iSCSI B VLAN');
     if (state.disaggBackupEnabled && !vlans.backup) missing.push('Backup VLAN');
 
     if (missing.length > 0) {
@@ -752,7 +753,8 @@ function renderQosSummary() {
     const container = document.getElementById('da5-qos-summary');
     if (!container) return;
 
-    const isIscsi = state.disaggStorageType === 'iscsi_4nic' || state.disaggStorageType === 'iscsi_6nic';
+    const isIscsi4Nic = state.disaggStorageType === 'iscsi_4nic';
+    const isIscsi6Nic = state.disaggStorageType === 'iscsi_6nic';
     const isFcSan = state.disaggStorageType === 'fc_san';
     const exp = document.getElementById('da5-explanation');
 
@@ -762,14 +764,13 @@ function renderQosSummary() {
         { priority: 7, desc: 'Cluster Heartbeat', pfc: 'No', bw: '1%' }
     ];
 
-    if (isIscsi) {
+    if (isIscsi6Nic) {
         rows.push({ priority: 4, desc: 'iSCSI Storage', pfc: 'No', bw: '50%' });
         rows[0].bw = '29%';
     }
 
-    // Backup traffic runs on a dedicated backup compute intent (PCIe adapter 2) with its own
-    // NICs/leaf ports, so it does NOT share bandwidth with the management/cluster ports shown
-    // in this QoS table. No row is added for backup, regardless of disaggBackupEnabled.
+    // Backup traffic is tenant-only: dedicated backup NICs for FC SAN, or a Backup VLAN
+    // trunk on ClusterBackupSwitch for 6-NIC iSCSI. No host QoS row is added here.
 
     rows.sort((a, b) => a.priority - b.priority);
 
@@ -798,10 +799,12 @@ function renderQosSummary() {
 
     if (exp) {
         const backupNote = state.disaggBackupEnabled
-            ? ' Backup traffic runs on a <strong>dedicated backup compute intent</strong> (PCIe adapter 2) with its own NICs and switch ports, so it doesn\'t consume bandwidth on the cluster/management ports above.'
+            ? ' Backup traffic is tenant-only: FC SAN uses dedicated backup NICs, while 6-NIC iSCSI trunks the Backup VLAN on <strong>ClusterBackupSwitch</strong> without a host backup vNIC.'
             : '';
         if (isFcSan) {
             exp.innerHTML = '<strong style="color: var(--accent-purple);">802.1p + ETS</strong> — QoS is required for CSV/Live Migration traffic even with FC SAN. Storage traffic runs on a separate Fibre Channel fabric and does not need Ethernet QoS, but cluster traffic sharing the leaf ports still needs traffic classification and bandwidth reservation.' + backupNote;
+        } else if (isIscsi4Nic) {
+            exp.innerHTML = '<strong style="color: var(--accent-purple);">802.1p + ETS</strong> — No PFC (Priority Flow Control) required. In the 4-NIC iSCSI layout, iSCSI sessions bind to the same standalone physical NICs, VLANs, and source IPs as Cluster A/B, with per-target /32 routes pinned to NIC3/NIC4. There is no separate iSCSI vSwitch, vNIC, or dedicated iSCSI QoS row.' + backupNote;
         } else {
             exp.innerHTML = '<strong style="color: var(--accent-purple);">802.1p + ETS</strong> — No PFC (Priority Flow Control) required. iSCSI is loss-tolerant unlike RDMA. 802.1p CoS marking with Weighted Round Robin (WRR) bandwidth allocation ensures each traffic class gets guaranteed bandwidth.' + backupNote;
         }
@@ -1346,16 +1349,13 @@ function getDisaggNicSlots() {
     // PCIe1: always present (2 ports) — Cluster (or Cluster+iSCSI in 4-NIC)
     const pcie1Label = st === 'iscsi_4nic' ? 'PCIe1 (Cluster + iSCSI Shared)' : 'PCIe1 (Cluster / CSV / Live Migration)';
     slots.push({ key: 'pcie1', label: pcie1Label, ports: 2, defaultSpeed: '25GbE', allowedSpeeds: ['10GbE', '25GbE', '100GbE'] });
-    // PCIe2: 6-NIC iSCSI dedicated (only when no backup)
-    if (st === 'iscsi_6nic' && !backup) {
+    // PCIe2: 6-NIC iSCSI dedicated, regardless of backup.
+    if (st === 'iscsi_6nic') {
         slots.push({ key: 'pcie2', label: 'PCIe2 (iSCSI Dedicated)', ports: 2, defaultSpeed: '25GbE', allowedSpeeds: ['10GbE', '25GbE', '100GbE'] });
     }
-    // PCIe2 as Backup: 6-NIC iSCSI + backup (iSCSI falls back to sharing cluster ports)
-    if (st === 'iscsi_6nic' && backup) {
-        slots.push({ key: 'pcie2', label: 'PCIe2 (Backup)', ports: 2, defaultSpeed: '25GbE', allowedSpeeds: ['10GbE', '25GbE', '100GbE'] });
-    }
-    // Backup: FC SAN or iSCSI 4-NIC with backup enabled
-    if (backup && st !== 'iscsi_6nic') {
+    // Backup: FC SAN uses dedicated backup NICs. iSCSI 6-NIC + backup trunks the
+    // Backup VLAN on ClusterBackupSwitch instead of adding backup adapters.
+    if (backup && st === 'fc_san') {
         slots.push({ key: 'backup', label: 'Backup (In-Guest VM Backup)', ports: 2, defaultSpeed: '25GbE', allowedSpeeds: ['10GbE', '25GbE', '100GbE'] });
     }
     // BMC: always (1 port, fixed 1GbE)
@@ -1449,10 +1449,10 @@ function getDisaggPortCountOptions() {
             options.push({ value: 6, label: '6 Ports', desc: 'OCP (2) + Cluster (2) + Backup (2). FC HBA handles storage separately.', dots: [6, 10, 14, 6, 10, 14], twoRow: true, disabled: true, disabledReason: 'Enable backup network on step DA2 to use 6 ports' });
         }
     } else if (st === 'iscsi_4nic') {
-        // Spec §4: backup is NOT supported on iSCSI 4-NIC.
+        // Backup is NOT supported on iSCSI 4-NIC.
         // Only the 4-port layout is valid; the 6-port card is always disabled.
-        options.push({ value: 4, label: '4 Ports', desc: 'OCP (2) + PCIe1 (2). NIC3/NIC4 wrapped in customer-managed ClusterISCSISwitch SET hosting Cluster1 vNIC / Cluster2 vNIC / iSCSI1 vNIC / iSCSI2 vNIC.', dots: [5, 9, 15, 19] });
-        options.push({ value: 6, label: '6 Ports', desc: 'Backup network is not supported on the iSCSI 4-NIC layout (spec §4). Switch storage type to iSCSI 6-NIC or FC SAN to enable backup.', dots: [6, 10, 14, 6, 10, 14], twoRow: true, disabled: true, disabledReason: 'Backup network is not supported on iSCSI 4-NIC. Switch to iSCSI 6-NIC or FC SAN.' });
+        options.push({ value: 4, label: '4 Ports', desc: 'OCP (2) + PCIe1 (2). NIC3/NIC4 are standalone physical adapters: NIC3 carries Cluster A + iSCSI Path A, NIC4 carries Cluster B + iSCSI Path B. No SET, no vSwitch, no host vNICs.', dots: [5, 9, 15, 19] });
+        options.push({ value: 6, label: '6 Ports', desc: 'Backup network is not supported on the iSCSI 4-NIC layout. Switch storage type to iSCSI 6-NIC or FC SAN to enable backup.', dots: [6, 10, 14, 6, 10, 14], twoRow: true, disabled: true, disabledReason: 'Backup network is not supported on iSCSI 4-NIC. Switch to iSCSI 6-NIC or FC SAN.' });
     } else if (st === 'iscsi_6nic') {
         if (backup) {
             options.push({ value: 6, label: '6 Ports', desc: 'OCP (2) + PCIe1 cluster SET on ClusterBackupSwitch (2, hosts Cluster1/Cluster2 + Backup VLAN trunk) + PCIe2 dedicated iSCSI Path A/B (2, standalone).', dots: [6, 10, 14, 6, 10, 14], twoRow: true });
@@ -1777,8 +1777,8 @@ function getDisaggIntentZones() {
         requiresRdma: false
     });
 
-    // Cluster Network 1 / 2 — transport depends on layout (spec §2.1, §3.1, §4.3):
-    //   iSCSI 4-NIC                : host vNIC on customer-managed WorkloadSwitch SET (NIC3/NIC4)
+    // Cluster Network 1 / 2 — transport depends on layout:
+    //   iSCSI 4-NIC                : standalone physical NIC3/NIC4 shared with iSCSI Path A/B
     //   iSCSI 6-NIC + backup       : host vNIC on customer-managed ClusterBackupSwitch SET (NIC3/NIC4) + Backup VLAN trunked
     //   iSCSI 6-NIC, no backup     : standalone bare-metal NIC (no SET, no host vNIC)
     //   FC SAN (any)               : standalone bare-metal NIC
@@ -1787,8 +1787,8 @@ function getDisaggIntentZones() {
     const cName2 = (typeof cNames.cluster2 === 'string' && cNames.cluster2.trim()) ? cNames.cluster2.trim() : 'Cluster Network 2';
     let clusterDescA, clusterDescB;
     if (st === 'iscsi_4nic') {
-        clusterDescA = 'Access port to Leaf-A on <code>ClusterISCSISwitch</code> SET (customer-managed, outside ATC). Shares NIC3 with iSCSI1 vNIC.';
-        clusterDescB = 'Access port to Leaf-B on <code>ClusterISCSISwitch</code> SET (customer-managed, outside ATC). Shares NIC4 with iSCSI2 vNIC.';
+        clusterDescA = 'Standalone physical <code>NIC3</code> to Leaf-A. Carries Cluster A and iSCSI Path A on the same VLAN/subnet/source IP. No SET, no vSwitch, no host vNIC.';
+        clusterDescB = 'Standalone physical <code>NIC4</code> to Leaf-B. Carries Cluster B and iSCSI Path B on the same VLAN/subnet/source IP. No SET, no vSwitch, no host vNIC.';
     } else if (st === 'iscsi_6nic' && backup) {
         clusterDescA = 'Host vNIC on <code>ClusterBackupSwitch</code> SET (customer-managed, outside ATC). Backup VLAN ' + (vlans.backup || 800) + ' trunked on the same SET (no host vNIC).';
         clusterDescB = 'Host vNIC on <code>ClusterBackupSwitch</code> SET (customer-managed, outside ATC). Backup VLAN ' + (vlans.backup || 800) + ' trunked on the same SET (no host vNIC).';
@@ -1823,7 +1823,7 @@ function getDisaggIntentZones() {
     if (st === 'iscsi_6nic') {
         zones.push({
             key: 'iscsi_a',
-            title: 'iSCSI Storage A (VLAN ' + (vlans.iscsiA || 500) + ')',
+            title: 'iSCSI Storage A (VLAN ' + (vlans.iscsiA || 300) + ')',
             description: 'Access port to Leaf-A. Dedicated iSCSI NIC, MTU 9216, MPIO.',
             titleClass: 'storage',
             cardClass: 'zone-storage',
@@ -1833,7 +1833,7 @@ function getDisaggIntentZones() {
         });
         zones.push({
             key: 'iscsi_b',
-            title: 'iSCSI Storage B (VLAN ' + (vlans.iscsiB || 600) + ')',
+            title: 'iSCSI Storage B (VLAN ' + (vlans.iscsiB || 400) + ')',
             description: 'Access port to Leaf-B. Dedicated iSCSI NIC, MTU 9216, MPIO.',
             titleClass: 'storage',
             cardClass: 'zone-storage',
@@ -1842,9 +1842,8 @@ function getDisaggIntentZones() {
             requiresRdma: false
         });
     }
-    // For iSCSI 4-NIC: iSCSI shares NIC3/NIC4 via WorkloadSwitch SET host vNICs
-    // (iSCSI1/iSCSI2). No separate iSCSI intent zones — the SET is customer-managed,
-    // not declared as an ATC intent.
+    // For iSCSI 4-NIC: iSCSI shares standalone physical NIC3/NIC4 with Cluster A/B.
+    // There are no separate iSCSI intent zones, SET switch, or host vNICs.
 
     // Compute Intent for In-Guest Backup Network — orange.
     // Spec §4: backup is supported on iSCSI 6-NIC (tenant VLAN trunked on cluster SET,
@@ -2273,8 +2272,11 @@ function renderDisaggOverrides() {
     const esc = (typeof escapeHtml === 'function') ? escapeHtml : function(s) { return String(s); };
 
     html += '<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; margin-bottom: 12px;">';
+    const cluster1TransportSuffix = st === 'iscsi_4nic' ? '(Physical NIC3 — Cluster + iSCSI Path A)' : '(Standalone)';
+    const cluster2TransportSuffix = st === 'iscsi_4nic' ? '(Physical NIC4 — Cluster + iSCSI Path B)' : '(Standalone)';
+
     html += '<div style="padding: 12px; border: 1px solid #22c55e40; border-left: 4px solid #22c55e; border-radius: 6px; background: #22c55e08; min-width: 0; overflow: hidden;">';
-    html += '<h5 style="margin: 0 0 8px 0; color: #22c55e;">' + esc(overrideCName1) + ' <span style="font-weight:400; color:var(--text-secondary); font-size:0.82rem;">(Standalone)</span></h5>';
+    html += '<h5 style="margin: 0 0 8px 0; color: #22c55e;">' + esc(overrideCName1) + ' <span style="font-weight:400; color:var(--text-secondary); font-size:0.82rem;">' + cluster1TransportSuffix + '</span></h5>';
     html += '<div style="margin-bottom:6px;"><label style="display:block; margin-bottom:4px; font-size:0.82rem; color:var(--text-secondary);">VLAN <span style="font-size:0.72rem; color:var(--accent-purple);">🔒 bound to DA4</span></label>';
     html += '<input type="number" value="' + cluster1Vlan + '" readonly title="' + cluster1Tip.replace(/"/g, '&quot;') + '" style="' + readonlyVlanStyle + '">';
     html += '</div><div><label style="display:block; margin-bottom:4px; font-size:0.82rem; color:var(--text-secondary);">Subnet (CIDR)</label>';
@@ -2282,7 +2284,7 @@ function renderDisaggOverrides() {
     html += '</div></div>';
 
     html += '<div style="padding: 12px; border: 1px solid #22c55e40; border-left: 4px solid #22c55e; border-radius: 6px; background: #22c55e08; min-width: 0; overflow: hidden;">';
-    html += '<h5 style="margin: 0 0 8px 0; color: #22c55e;">' + esc(overrideCName2) + ' <span style="font-weight:400; color:var(--text-secondary); font-size:0.82rem;">(Standalone)</span></h5>';
+    html += '<h5 style="margin: 0 0 8px 0; color: #22c55e;">' + esc(overrideCName2) + ' <span style="font-weight:400; color:var(--text-secondary); font-size:0.82rem;">' + cluster2TransportSuffix + '</span></h5>';
     html += '<div style="margin-bottom:6px;"><label style="display:block; margin-bottom:4px; font-size:0.82rem; color:var(--text-secondary);">VLAN <span style="font-size:0.72rem; color:var(--accent-purple);">🔒 bound to DA4</span></label>';
     html += '<input type="number" value="' + cluster2Vlan + '" readonly title="' + cluster2Tip.replace(/"/g, '&quot;') + '" style="' + readonlyVlanStyle + '">';
     html += '</div><div><label style="display:block; margin-bottom:4px; font-size:0.82rem; color:var(--text-secondary);">Subnet (CIDR)</label>';
@@ -2290,28 +2292,32 @@ function renderDisaggOverrides() {
     html += '</div></div>';
     html += '</div>';
 
-    // ── iSCSI Overrides — required for any iSCSI scenario:
-    //   iscsi_4nic           : NIC3/NIC4 host iSCSI1/iSCSI2 vNICs in ClusterISCSISwitch SET
-    //   iscsi_6nic, no backup: NIC5/NIC6 standalone iSCSI Path A/B (bare-metal)
-    //   iscsi_6nic + backup  : NIC5/NIC6 standalone iSCSI Path A/B unchanged (NIC3/NIC4 host Cluster1/Cluster2 vNICs + Backup trunk in ClusterBackupSwitch SET)
-    const hasIscsi = (st === 'iscsi_4nic' || st === 'iscsi_6nic');
-    if (hasIscsi) {
-        const iscsiSuffix = (st === 'iscsi_4nic') ? '(SET vNIC — ClusterISCSISwitch)' : '(Standalone)';
+    if (st === 'iscsi_4nic') {
+        html += '<div class="info-box warning visible" style="margin-bottom: 12px;">'
+            + '<strong>4-NIC shared physical fabric</strong>'
+            + '<p style="margin:6px 0 0 0;">iSCSI Path A uses the ' + esc(overrideCName1) + ' VLAN/subnet and source IP on physical <code>NIC3</code>; iSCSI Path B uses the ' + esc(overrideCName2) + ' VLAN/subnet and source IP on physical <code>NIC4</code>. Do not create <code>ClusterISCSISwitch</code>, <code>Cluster1</code>/<code>Cluster2</code> host vNICs, or <code>iSCSI1</code>/<code>iSCSI2</code> host vNICs. Target portal /32 routes must be pinned to the matching physical NIC.</p>'
+            + '</div>';
+    }
+
+    // ── Dedicated iSCSI Overrides — only iSCSI 6-NIC has separate Path A/B
+    // VLAN/subnet inputs. In 4-NIC mode, iSCSI derives from Cluster A/B above.
+    if (st === 'iscsi_6nic') {
+        const iscsiSuffix = '(Standalone)';
         html += '<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 12px; margin-bottom: 12px;">';
         html += '<div style="padding: 12px; border: 1px solid #8b5cf640; border-left: 4px solid #8b5cf6; border-radius: 6px; background: #8b5cf608; min-width: 0; overflow: hidden;">';
         html += '<h5 style="margin: 0 0 8px 0; color: #8b5cf6;">iSCSI Network A <span style="font-weight:400; color:var(--text-secondary); font-size:0.82rem;">' + iscsiSuffix + '</span></h5>';
         html += '<div style="margin-bottom:6px;"><label style="display:block; margin-bottom:4px; font-size:0.82rem; color:var(--text-secondary);">VLAN</label>';
-        html += renderInput('iscsiA', 'iscsiA_vlan', vlans.iscsiA || 500, '', 'number', confirmed);
+        html += renderInput('iscsiA', 'iscsiA_vlan', vlans.iscsiA || 300, '', 'number', confirmed);
         html += '</div><div><label style="display:block; margin-bottom:4px; font-size:0.82rem; color:var(--text-secondary);">Subnet (CIDR)</label>';
-        html += renderInput('iscsiA', 'iscsiA_subnet', subnets.iscsiA || '10.50.1.0/24', '10.50.1.0/24', 'text', confirmed);
+        html += renderInput('iscsiA', 'iscsiA_subnet', subnets.iscsiA || '10.30.30.0/24', '10.30.30.0/24', 'text', confirmed);
         html += '</div></div>';
 
         html += '<div style="padding: 12px; border: 1px solid #8b5cf640; border-left: 4px solid #8b5cf6; border-radius: 6px; background: #8b5cf608; min-width: 0; overflow: hidden;">';
         html += '<h5 style="margin: 0 0 8px 0; color: #8b5cf6;">iSCSI Network B <span style="font-weight:400; color:var(--text-secondary); font-size:0.82rem;">' + iscsiSuffix + '</span></h5>';
         html += '<div style="margin-bottom:6px;"><label style="display:block; margin-bottom:4px; font-size:0.82rem; color:var(--text-secondary);">VLAN</label>';
-        html += renderInput('iscsiB', 'iscsiB_vlan', vlans.iscsiB || 600, '', 'number', confirmed);
+        html += renderInput('iscsiB', 'iscsiB_vlan', vlans.iscsiB || 400, '', 'number', confirmed);
         html += '</div><div><label style="display:block; margin-bottom:4px; font-size:0.82rem; color:var(--text-secondary);">Subnet (CIDR)</label>';
-        html += renderInput('iscsiB', 'iscsiB_subnet', subnets.iscsiB || '10.60.1.0/24', '10.60.1.0/24', 'text', confirmed);
+        html += renderInput('iscsiB', 'iscsiB_subnet', subnets.iscsiB || '10.40.40.0/24', '10.40.40.0/24', 'text', confirmed);
         html += '</div></div>';
         html += '</div>';
     }
@@ -2379,8 +2385,7 @@ function updateDisaggOverride(networkKey, fieldId, value) {
 function validateDisaggSubnets() {
     const subnets = state.disaggSubnets || {};
     const st = state.disaggStorageType || 'fc_san';
-    const backup = !!state.disaggBackupEnabled;
-    const hasDedicatedIscsi = (st === 'iscsi_6nic' && !backup);
+    const hasDedicatedIscsi = (st === 'iscsi_6nic');
 
     // Collect all active subnet keys and their values
     const entries = [
@@ -2449,8 +2454,7 @@ function confirmDisaggOverrides() {
     const vlans = state.disaggVlans || {};
     const subnets = state.disaggSubnets || {};
     const st = state.disaggStorageType || 'fc_san';
-    const backup = !!state.disaggBackupEnabled;
-    const hasIscsi = (st === 'iscsi_4nic' || st === 'iscsi_6nic');
+    const requiresDedicatedIscsiFields = st === 'iscsi_6nic';
     const missing = [];
 
     if (!vlans.cluster1) missing.push('Cluster 1 VLAN');
@@ -2458,7 +2462,7 @@ function confirmDisaggOverrides() {
     if (!vlans.cluster2) missing.push('Cluster 2 VLAN');
     if (!(subnets.cluster2 || '').trim()) missing.push('Cluster 2 Subnet');
 
-    if (hasIscsi) {
+    if (requiresDedicatedIscsiFields) {
         if (!vlans.iscsiA) missing.push('iSCSI A VLAN');
         if (!(subnets.iscsiA || '').trim()) missing.push('iSCSI A Subnet');
         if (!vlans.iscsiB) missing.push('iSCSI B VLAN');
@@ -2501,18 +2505,15 @@ function renderDisaggHostNetworkingPreview() {
     const portCount = parseInt(state.disaggPortCount, 10) || 4;
     const hasFc = (storageType === 'fc_san');
     const hasIscsi = (storageType === 'iscsi_4nic' || storageType === 'iscsi_6nic');
+    const is4NicSharedClusterIscsi = storageType === 'iscsi_4nic';
     const adapterMapping = state.disaggAdapterMapping || {};
 
-    // Cluster NIC SET wrapper mode (spec §3.2 / §4.3):
-    //   'workload'       — iSCSI 4-NIC: WorkloadSwitch on NIC3/NIC4 with Cluster1/Cluster2/iSCSI1/iSCSI2 host vNICs
+    // Cluster NIC SET wrapper mode:
     //   'clusterbackup'  — iSCSI 6-NIC + backup: ClusterBackupSwitch on NIC3/NIC4 with Cluster1/Cluster2 host vNICs + Backup VLAN trunk
-    //   null             — standalone bare-metal cluster NICs (iSCSI 6-NIC no backup, FC SAN)
-    const clusterSetMode = (storageType === 'iscsi_4nic') ? 'workload'
-        : (storageType === 'iscsi_6nic' && backupEnabled) ? 'clusterbackup'
-            : null;
-    const clusterSetName = clusterSetMode === 'workload' ? 'ClusterISCSISwitch'
-        : clusterSetMode === 'clusterbackup' ? 'ClusterBackupSwitch'
-            : null;
+    //   null             — standalone physical cluster NICs (including iSCSI 4-NIC)
+    const clusterSetMode = (storageType === 'iscsi_6nic' && backupEnabled) ? 'clusterbackup' : null;
+    const clusterSetName = clusterSetMode === 'clusterbackup' ? 'ClusterBackupSwitch'
+        : null;
 
     function colorRgb(hex) {
         return parseInt(hex.slice(1, 3), 16) + ',' + parseInt(hex.slice(3, 5), 16) + ',' + parseInt(hex.slice(5, 7), 16);
@@ -2533,31 +2534,17 @@ function renderDisaggHostNetworkingPreview() {
     // Zone metadata. vnicsAbove is an array of host vNICs to stack above the NIC group.
     // vlansBelow is an array of italicised VLAN tags rendered under the group label.
     const vlans = state.disaggVlans || {};
-    const cluster1VnicsAbove = clusterSetMode === 'workload'
-        ? [
-            { name: 'Cluster1 vNIC', vlan: 'VLAN ' + (vlans.cluster1 || '711') },
-            { name: 'iSCSI1 vNIC', vlan: 'VLAN ' + (vlans.iscsiA || '300'), color: '#f97316' }
-        ]
-        : clusterSetMode === 'clusterbackup'
-            ? [{ name: 'Cluster1 vNIC', vlan: 'VLAN ' + (vlans.cluster1 || '711') }]
-            : [];
-    const cluster2VnicsAbove = clusterSetMode === 'workload'
-        ? [
-            { name: 'Cluster2 vNIC', vlan: 'VLAN ' + (vlans.cluster2 || '712') },
-            { name: 'iSCSI2 vNIC', vlan: 'VLAN ' + (vlans.iscsiB || '400'), color: '#f97316' }
-        ]
-        : clusterSetMode === 'clusterbackup'
-            ? [{ name: 'Cluster2 vNIC', vlan: 'VLAN ' + (vlans.cluster2 || '712') }]
-            : [];
-    const cluster1VlansBelow = clusterSetMode === 'workload'
-        ? ['VLAN ' + (vlans.cluster1 || '711'), 'VLAN ' + (vlans.iscsiA || '300')]
-        : ['VLAN ' + (vlans.cluster1 || '711')];
-    const cluster2VlansBelow = clusterSetMode === 'workload'
-        ? ['VLAN ' + (vlans.cluster2 || '712'), 'VLAN ' + (vlans.iscsiB || '400')]
-        : ['VLAN ' + (vlans.cluster2 || '712')];
-    const clusterLabel1 = (clusterSetMode === 'workload') ? 'NIC3 (SET member)' : 'Cluster Network 1';
-    const clusterLabel2 = (clusterSetMode === 'workload') ? 'NIC4 (SET member)' : 'Cluster Network 2';
-    const clusterSubLabel = (clusterSetMode === 'workload') ? 'shared cluster + iSCSI'
+    const cluster1VnicsAbove = clusterSetMode === 'clusterbackup'
+        ? [{ name: 'Cluster1 vNIC', vlan: 'VLAN ' + (vlans.cluster1 || '711') }]
+        : [];
+    const cluster2VnicsAbove = clusterSetMode === 'clusterbackup'
+        ? [{ name: 'Cluster2 vNIC', vlan: 'VLAN ' + (vlans.cluster2 || '712') }]
+        : [];
+    const cluster1VlansBelow = ['VLAN ' + (vlans.cluster1 || '711')];
+    const cluster2VlansBelow = ['VLAN ' + (vlans.cluster2 || '712')];
+    const clusterLabel1 = is4NicSharedClusterIscsi ? 'NIC3 Path A' : 'Cluster Network 1';
+    const clusterLabel2 = is4NicSharedClusterIscsi ? 'NIC4 Path B' : 'Cluster Network 2';
+    const clusterSubLabel = is4NicSharedClusterIscsi ? 'Cluster + iSCSI'
         : (clusterSetMode === 'clusterbackup') ? 'shared cluster + Backup VLAN trunk'
             : 'standalone — no SET';
 
@@ -2587,14 +2574,14 @@ function renderDisaggHostNetworkingPreview() {
             label: 'iSCSI Storage A',
             color: '#8b5cf6',
             subLabel: 'standalone — no SET',
-            vlansBelow: ['VLAN ' + (vlans.iscsiA || '500')],
+            vlansBelow: ['VLAN ' + (vlans.iscsiA || '300')],
             forcedLeaf: 'A'
         },
         iscsi_b: {
             label: 'iSCSI Storage B',
             color: '#8b5cf6',
             subLabel: 'standalone — no SET',
-            vlansBelow: ['VLAN ' + (vlans.iscsiB || '600')],
+            vlansBelow: ['VLAN ' + (vlans.iscsiB || '400')],
             forcedLeaf: 'B'
         },
         backup: { label: 'In-Guest Backup Compute Intent', color: '#f97316' }
@@ -2630,8 +2617,8 @@ function renderDisaggHostNetworkingPreview() {
         nicGroups.push(grp);
     }
 
-    // When a SET wraps the cluster NICs (4-NIC ClusterISCSISwitch / 6-NIC+backup
-    // ClusterBackupSwitch), merge cluster_1 + cluster_2 into a single "cluster_set"
+    // When 6-NIC+backup wraps the cluster NICs in ClusterBackupSwitch,
+    // merge cluster_1 + cluster_2 into a single "cluster_set"
     // group so NIC3 and NIC4 share one dashed box (same UX as Mgmt+Compute combining
     // OCP-NIC1 + OCP-NIC2). The merged group's own box becomes the SET visual wrapper
     // — no separate overlay rectangle is needed.
@@ -2648,7 +2635,7 @@ function renderDisaggHostNetworkingPreview() {
                 nics: c1.nics.concat(c2.nics),
                 vnicsAbove: (c1.vnicsAbove || []).concat(c2.vnicsAbove || []),
                 isSet: true,
-                showBackupBadge: clusterSetMode === 'clusterbackup'
+                showBackupBadge: true
             };
             // Replace c1 with merged; remove c2 (keep zone order: merged sits where c1 was).
             nicGroups.splice(Math.max(c1Idx, c2Idx), 1);
@@ -2744,13 +2731,21 @@ function renderDisaggHostNetworkingPreview() {
         const _c2 = (function(){ for (let i=0;i<nicGroups.length;i++) if (nicGroups[i].key==='cluster_2') return nicGroups[i]; return null; })();
         if (_c1 || _c2) {
             const allClusterNics = [].concat(_c1?_c1.nics.map(n=>n.name):[]).concat(_c2?_c2.nics.map(n=>n.name):[]);
-            legendEntries.push({
-                title: 'Cluster Networks (standalone — no SET)',
-                color: '#22c55e',
-                lines: [
+            const clusterLegendTitle = is4NicSharedClusterIscsi ? 'Shared Cluster + iSCSI Physical Paths (standalone — no SET)' : 'Cluster Networks (standalone — no SET)';
+            const clusterLegendLines = is4NicSharedClusterIscsi
+                ? [
+                    'Members: ' + allClusterNics.join(', '),
+                    'Path A/B VLANs: ' + (vlans.cluster1 || '711') + ', ' + (vlans.cluster2 || '712') + ' — iSCSI uses the same physical NIC source IPs',
+                    'Host vNICs: none; target portal /32 routes are pinned to NIC3/NIC4'
+                ]
+                : [
                     'Members: ' + allClusterNics.join(', '),
                     'VLANs: ' + (vlans.cluster1 || '711') + ', ' + (vlans.cluster2 || '712') + ' (bare-metal, no host vNIC)'
-                ]
+                ];
+            legendEntries.push({
+                title: clusterLegendTitle,
+                color: '#22c55e',
+                lines: clusterLegendLines
             });
         }
     }
@@ -2763,7 +2758,7 @@ function renderDisaggHostNetworkingPreview() {
             color: '#8b5cf6',
             lines: [
                 'Members: ' + allIscsi.join(', '),
-                'VLANs: ' + (vlans.iscsiA || '500') + ' (Path A), ' + (vlans.iscsiB || '600') + ' (Path B) — MPIO, bare-metal'
+                'VLANs: ' + (vlans.iscsiA || '300') + ' (Path A), ' + (vlans.iscsiB || '400') + ' (Path B) — MPIO, bare-metal'
             ]
         });
     }

--- a/js/script.js
+++ b/js/script.js
@@ -295,8 +295,8 @@ const state = {
     disaggRackCount: null,
     disaggNodesPerRack: null,
     disaggSpineCount: null,
-    disaggVlans: { mgmt: 7, cluster1: 711, cluster2: 712, iscsiA: 500, iscsiB: 600, backup: 800 },
-    disaggVnis: { mgmt: 10007, cluster1: 10711, cluster2: 10712, iscsiA: 10500, iscsiB: 10600, backup: 10800 },
+    disaggVlans: { mgmt: 7, cluster1: 711, cluster2: 712, iscsiA: 300, iscsiB: 400, backup: 800 },
+    disaggVnis: { mgmt: 10007, cluster1: 10711, cluster2: 10712, iscsiA: 10300, iscsiB: 10400, backup: 10800 },
     disaggMgmtVlanMode: 'access',
     // Per MS Disaggregated-storage docs, cluster VLANs (1711/1712) are configured
     // in access mode on leaf ports by default — the leaf tags/strips and the host
@@ -312,7 +312,7 @@ const state = {
     disaggClusterNetworkNames: { cluster1: 'Cluster Network 1', cluster2: 'Cluster Network 2' },
     disaggVrfName: 'AZLOCALINFRA',
     disaggVrfMode: 'single',
-    disaggSubnets: { cluster1: '10.71.1.0/24', cluster2: '10.71.2.0/24', iscsiA: '10.50.1.0/24', iscsiB: '10.60.1.0/24' },
+    disaggSubnets: { cluster1: '10.71.1.0/24', cluster2: '10.71.2.0/24', iscsiA: '10.30.30.0/24', iscsiB: '10.40.40.0/24' },
     disaggIscsiTargets: [],
     disaggQosCustomized: false,
     // DA9: Node configuration
@@ -6861,7 +6861,10 @@ function updateSummary() {
             if (dv.mgmt != null) vlanLines.push(`Management: ${dv.mgmt}`);
             if (dv.cluster1 != null) vlanLines.push(`Cluster 1: ${dv.cluster1}`);
             if (dv.cluster2 != null) vlanLines.push(`Cluster 2: ${dv.cluster2}`);
-            if (state.disaggStorageType !== 'fc_san') {
+            if (state.disaggStorageType === 'iscsi_4nic') {
+                vlanLines.push('iSCSI-A: shared with Cluster 1');
+                vlanLines.push('iSCSI-B: shared with Cluster 2');
+            } else if (state.disaggStorageType === 'iscsi_6nic') {
                 if (dv.iscsiA != null) vlanLines.push(`iSCSI-A: ${dv.iscsiA}`);
                 if (dv.iscsiB != null) vlanLines.push(`iSCSI-B: ${dv.iscsiB}`);
             }
@@ -9809,9 +9812,9 @@ function startFresh() {
             // These object properties should be null or empty object initially
             state[key] = (key === 'infra') ? null : {};
         } else if (key === 'disaggVlans') {
-            state[key] = { mgmt: 7, cluster1: 711, cluster2: 712, iscsiA: 500, iscsiB: 600, backup: 800 };
+            state[key] = { mgmt: 7, cluster1: 711, cluster2: 712, iscsiA: 300, iscsiB: 400, backup: 800 };
         } else if (key === 'disaggVnis') {
-            state[key] = { mgmt: 10007, cluster1: 10711, cluster2: 10712, iscsiA: 10500, iscsiB: 10600, backup: 10800 };
+            state[key] = { mgmt: 10007, cluster1: 10711, cluster2: 10712, iscsiA: 10300, iscsiB: 10400, backup: 10800 };
         } else if (key === 'disaggVrfName') {
             state[key] = 'AZLOCALINFRA';
         } else if (key === 'disaggNicNames') {
@@ -10247,13 +10250,13 @@ function showTemplates() {
                 disaggRackCount: 4,
                 disaggNodesPerRack: 16,
                 disaggSpineCount: 2,
-                disaggVlans: { mgmt: 7, cluster1: 1711, cluster2: 1712, iscsiA: 500, iscsiB: 600, backup: 800 },
-                disaggVnis: { mgmt: 10007, cluster1: 10711, cluster2: 10712, iscsiA: 10500, iscsiB: 10600, backup: 10800 },
+                disaggVlans: { mgmt: 7, cluster1: 1711, cluster2: 1712, iscsiA: 300, iscsiB: 400, backup: 800 },
+                disaggVnis: { mgmt: 10007, cluster1: 10711, cluster2: 10712, iscsiA: 10300, iscsiB: 10400, backup: 10800 },
                 disaggMgmtVlanMode: 'access',
                 disaggClusterVlanMode: { cluster1: 'access', cluster2: 'access' },
                 disaggVrfName: 'AZLOCALINFRA',
                 disaggVrfMode: 'single',
-                disaggSubnets: { cluster1: '10.71.1.0/24', cluster2: '10.71.2.0/24', iscsiA: '10.50.1.0/24', iscsiB: '10.60.1.0/24' },
+                disaggSubnets: { cluster1: '10.71.1.0/24', cluster2: '10.71.2.0/24', iscsiA: '10.30.30.0/24', iscsiB: '10.40.40.0/24' },
                 disaggQosCustomized: false,
                 disaggPortSpeeds: { ocp: '25GbE', pcie1: '25GbE', pcie2: '25GbE', backup: '25GbE', bmc: '1GbE' },
                 disaggIntentMapping: { mgmt_compute: ['ocp_p1', 'ocp_p2'] },

--- a/report/report.js
+++ b/report/report.js
@@ -1777,11 +1777,10 @@
             { id: 'pcie1_p2', defaultName: 'PCIe1-NIC4', slot: 'pcie1' }
         ];
         if (storageType === 'iscsi_6nic') {
-            var pcie2Slot = backupEnabled ? 'backup' : 'pcie2';
-            ports.push({ id: 'pcie2_p1', defaultName: 'PCIe2-NIC5', slot: pcie2Slot });
-            ports.push({ id: 'pcie2_p2', defaultName: 'PCIe2-NIC6', slot: pcie2Slot });
+            ports.push({ id: 'pcie2_p1', defaultName: 'PCIe2-NIC5', slot: 'pcie2' });
+            ports.push({ id: 'pcie2_p2', defaultName: 'PCIe2-NIC6', slot: 'pcie2' });
         }
-        if (backupEnabled && storageType !== 'iscsi_6nic') {
+        if (backupEnabled && storageType === 'fc_san') {
             ports.push({ id: 'backup_p1', defaultName: 'BK-NIC1', slot: 'backup' });
             ports.push({ id: 'backup_p2', defaultName: 'BK-NIC2', slot: 'backup' });
         }
@@ -2265,8 +2264,8 @@
         var n = Math.min(2, totalNodes);
         var hasFc = (storageType === 'fc_san');
         var hasIscsi = (storageType === 'iscsi_4nic' || storageType === 'iscsi_6nic');
-        var hasDedicatedIscsi = (storageType === 'iscsi_6nic' && !backupEnabled);
-        var hasSharedIscsi = (storageType === 'iscsi_4nic' || (storageType === 'iscsi_6nic' && backupEnabled));
+        var hasDedicatedIscsi = (storageType === 'iscsi_6nic');
+        var hasSharedIscsi = (storageType === 'iscsi_4nic');
         var adapterMapping = s.disaggAdapterMapping || {};
 
         function xmlEsc(str) {
@@ -2300,14 +2299,14 @@
 
         // Build NIC groups dynamically from adapter mapping
         var nicGroups = [];
-        var dClusterLabel1 = hasSharedIscsi ? 'CSV/LiveMig' : 'Cluster 1';
-        var dClusterLabel2 = hasSharedIscsi ? 'CSV/LiveMig' : 'Cluster 2';
+        var dClusterLabel1 = hasSharedIscsi ? 'NIC3 Path A' : 'Cluster 1';
+        var dClusterLabel2 = hasSharedIscsi ? 'NIC4 Path B' : 'Cluster 2';
         var zoneMeta = {
             mgmt_compute: { label: 'Mgmt + Compute', color: 'blue', vnicAbove: { name: 'Mgmt vNIC', vlan: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.mgmt) || '7') } },
-            cluster_1: { label: dClusterLabel1, color: 'green', subLabel: hasSharedIscsi ? '+ iSCSI' : '', vlanBelow: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.cluster1) || '711'), forcedLeaf: 'A' },
-            cluster_2: { label: dClusterLabel2, color: 'green', subLabel: hasSharedIscsi ? '+ iSCSI' : '', vlanBelow: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.cluster2) || '712'), forcedLeaf: 'B' },
-            iscsi_a: { label: 'iSCSI Storage A', color: 'purple', vlanBelow: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.iscsiA) || '500'), forcedLeaf: 'A' },
-            iscsi_b: { label: 'iSCSI Storage B', color: 'purple', vlanBelow: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.iscsiB) || '600'), forcedLeaf: 'B' },
+            cluster_1: { label: dClusterLabel1, color: 'green', subLabel: hasSharedIscsi ? 'Cluster + iSCSI' : '', vlanBelow: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.cluster1) || '711'), forcedLeaf: 'A' },
+            cluster_2: { label: dClusterLabel2, color: 'green', subLabel: hasSharedIscsi ? 'Cluster + iSCSI' : '', vlanBelow: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.cluster2) || '712'), forcedLeaf: 'B' },
+            iscsi_a: { label: 'iSCSI Storage A', color: 'purple', vlanBelow: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.iscsiA) || '300'), forcedLeaf: 'A' },
+            iscsi_b: { label: 'iSCSI Storage B', color: 'purple', vlanBelow: 'VLAN ' + ((s.disaggVlans && s.disaggVlans.iscsiB) || '400'), forcedLeaf: 'B' },
             backup: { label: 'In-Guest Backup Compute Intent', color: 'orange' }
         };
         var zoneOrder = ['mgmt_compute', 'cluster_1', 'cluster_2', 'iscsi_a', 'iscsi_b', 'backup'];
@@ -4202,8 +4201,8 @@
             var n = Math.min(2, totalNodes);
             var hasFc = (storageType === 'fc_san');
             var hasIscsi = (storageType === 'iscsi_4nic' || storageType === 'iscsi_6nic');
-            var hasDedicatedIscsi = (storageType === 'iscsi_6nic' && !backupEnabled);
-            var hasSharedIscsi = (storageType === 'iscsi_4nic' || (storageType === 'iscsi_6nic' && backupEnabled));
+            var hasDedicatedIscsi = (storageType === 'iscsi_6nic');
+            var hasSharedIscsi = (storageType === 'iscsi_4nic');
             var adapterMapping = state.disaggAdapterMapping || {};
 
             // NIC name helper — port IDs must match wizard format: ocp_p1, pcie1_p2, etc.
@@ -4239,42 +4238,28 @@
             var nicGroups = [];
 
             // Cluster NIC SET wrapper mode (mirrors wizard preview):
-            //   'workload'      — iSCSI 4-NIC: ClusterISCSI SET on NIC3/NIC4 (Cluster1/2 + iSCSI1/2 vNICs)
             //   'clusterbackup' — iSCSI 6-NIC + backup: ClusterBackupSwitch SET (Cluster1/2 vNICs + Backup VLAN trunk)
-            //   null            — standalone bare-metal cluster NICs (FC SAN, iSCSI 6-NIC no backup)
-            var clusterSetMode = (storageType === 'iscsi_4nic') ? 'workload'
-                : (storageType === 'iscsi_6nic' && backupEnabled) ? 'clusterbackup'
-                    : null;
-            var clusterSetName = clusterSetMode === 'workload' ? 'ClusterISCSISwitch'
-                : clusterSetMode === 'clusterbackup' ? 'ClusterBackupSwitch'
+            //   null            — standalone physical cluster NICs, including iSCSI 4-NIC shared paths
+            var clusterSetMode = (storageType === 'iscsi_6nic' && backupEnabled) ? 'clusterbackup' : null;
+            var clusterSetName = clusterSetMode === 'clusterbackup' ? 'ClusterBackupSwitch'
                     : null;
             var vlansState = state.disaggVlans || {};
-            var cluster1VnicsAbove = clusterSetMode === 'workload'
-                ? [
-                    { name: 'Cluster1 vNIC', vlan: 'VLAN ' + (vlansState.cluster1 || '711') },
-                    { name: 'iSCSI1 vNIC', vlan: 'VLAN ' + (vlansState.iscsiA || '500'), color: '#f97316' }
-                ]
-                : clusterSetMode === 'clusterbackup'
+            var cluster1VnicsAbove = clusterSetMode === 'clusterbackup'
                     ? [{ name: 'Cluster1 vNIC', vlan: 'VLAN ' + (vlansState.cluster1 || '711') }]
                     : [];
-            var cluster2VnicsAbove = clusterSetMode === 'workload'
-                ? [
-                    { name: 'Cluster2 vNIC', vlan: 'VLAN ' + (vlansState.cluster2 || '712') },
-                    { name: 'iSCSI2 vNIC', vlan: 'VLAN ' + (vlansState.iscsiB || '600'), color: '#f97316' }
-                ]
-                : clusterSetMode === 'clusterbackup'
+            var cluster2VnicsAbove = clusterSetMode === 'clusterbackup'
                     ? [{ name: 'Cluster2 vNIC', vlan: 'VLAN ' + (vlansState.cluster2 || '712') }]
                     : [];
 
-            // Define zone metadata — for shared iSCSI, cluster groups carry CSV/LiveMig + iSCSI traffic
-            var clusterLabel1 = hasSharedIscsi ? 'CSV/LiveMig' : 'Cluster 1';
-            var clusterLabel2 = hasSharedIscsi ? 'CSV/LiveMig' : 'Cluster 2';
+            // Define zone metadata — for 4-NIC, cluster groups are physical shared Cluster+iSCSI paths.
+            var clusterLabel1 = hasSharedIscsi ? 'NIC3 Path A' : 'Cluster 1';
+            var clusterLabel2 = hasSharedIscsi ? 'NIC4 Path B' : 'Cluster 2';
             var zoneMeta = {
                 mgmt_compute: { label: 'Mgmt + Compute', color: '#3b82f6', vnicsAbove: [{ name: 'Mgmt vNIC', vlan: 'VLAN ' + (vlansState.mgmt || '7') }] },
-                cluster_1: { label: clusterLabel1, color: '#22c55e', subLabel: hasSharedIscsi ? '+ iSCSI' : '', vnicsAbove: cluster1VnicsAbove, vlanBelow: 'VLAN ' + (vlansState.cluster1 || '711'), forcedLeaf: 'A' },
-                cluster_2: { label: clusterLabel2, color: '#22c55e', subLabel: hasSharedIscsi ? '+ iSCSI' : '', vnicsAbove: cluster2VnicsAbove, vlanBelow: 'VLAN ' + (vlansState.cluster2 || '712'), forcedLeaf: 'B' },
-                iscsi_a: { label: 'iSCSI Storage A', color: '#8b5cf6', vlanBelow: 'VLAN ' + (vlansState.iscsiA || '500'), forcedLeaf: 'A' },
-                iscsi_b: { label: 'iSCSI Storage B', color: '#8b5cf6', vlanBelow: 'VLAN ' + (vlansState.iscsiB || '600'), forcedLeaf: 'B' },
+                cluster_1: { label: clusterLabel1, color: '#22c55e', subLabel: hasSharedIscsi ? 'Cluster + iSCSI' : '', vnicsAbove: cluster1VnicsAbove, vlanBelow: 'VLAN ' + (vlansState.cluster1 || '711'), forcedLeaf: 'A' },
+                cluster_2: { label: clusterLabel2, color: '#22c55e', subLabel: hasSharedIscsi ? 'Cluster + iSCSI' : '', vnicsAbove: cluster2VnicsAbove, vlanBelow: 'VLAN ' + (vlansState.cluster2 || '712'), forcedLeaf: 'B' },
+                iscsi_a: { label: 'iSCSI Storage A', color: '#8b5cf6', vlanBelow: 'VLAN ' + (vlansState.iscsiA || '300'), forcedLeaf: 'A' },
+                iscsi_b: { label: 'iSCSI Storage B', color: '#8b5cf6', vlanBelow: 'VLAN ' + (vlansState.iscsiB || '400'), forcedLeaf: 'B' },
                 backup: { label: 'In-Guest Backup Compute Intent', color: '#f97316' }
             };
 
@@ -4481,13 +4466,21 @@
                 if (sc1 || sc2) {
                     var allClusterNics = [].concat(sc1 ? sc1.nics.map(function(nx){ return nx.name; }) : [])
                         .concat(sc2 ? sc2.nics.map(function(nx){ return nx.name; }) : []);
-                    legendEntries.push({
-                        title: 'Cluster Networks (standalone — no SET)',
-                        color: '#22c55e',
-                        lines: [
+                    var clusterLegendTitle = hasSharedIscsi ? 'Shared Cluster + iSCSI Physical Paths (standalone — no SET)' : 'Cluster Networks (standalone — no SET)';
+                    var clusterLegendLines = hasSharedIscsi
+                        ? [
+                            'Members: ' + allClusterNics.join(', '),
+                            'Path A/B VLANs: ' + (vlansState.cluster1 || '711') + ', ' + (vlansState.cluster2 || '712') + ' — iSCSI uses the same physical NIC source IPs',
+                            'Host vNICs: none; target portal /32 routes are pinned to NIC3/NIC4'
+                        ]
+                        : [
                             'Members: ' + allClusterNics.join(', '),
                             'VLANs: ' + (vlansState.cluster1 || '711') + ', ' + (vlansState.cluster2 || '712') + ' (bare-metal, no host vNIC)'
-                        ]
+                        ];
+                    legendEntries.push({
+                        title: clusterLegendTitle,
+                        color: '#22c55e',
+                        lines: clusterLegendLines
                     });
                 }
             }
@@ -4500,7 +4493,7 @@
                     color: '#8b5cf6',
                     lines: [
                         'Members: ' + allIscsi.join(', '),
-                        'VLANs: ' + (vlansState.iscsiA || '500') + ' (Path A), ' + (vlansState.iscsiB || '600') + ' (Path B) — MPIO, bare-metal'
+                        'VLANs: ' + (vlansState.iscsiA || '300') + ' (Path A), ' + (vlansState.iscsiB || '400') + ' (Path B) — MPIO, bare-metal'
                     ]
                 });
             }
@@ -4794,10 +4787,10 @@
             var intro = ''
                 + '<div style="color:var(--text-secondary); margin-bottom:0.6rem;">'
                 + '<strong style="color:var(--text-primary);">Disaggregated (' + escapeHtml(storageLabel) + ')</strong> host networking diagram with Leaf-A / Leaf-B switches.'
-                + '<br>Intents: Management + Compute (SET), ' + (hasSharedIscsi ? 'CSV/LiveMig + iSCSI (Standalone)' : 'Cluster 1 &amp; 2 (Standalone)')
+                + '<br>Intents: Management + Compute (SET), ' + (hasSharedIscsi ? 'Cluster A/B + iSCSI Path A/B (Physical NIC3/NIC4, no SET)' : 'Cluster 1 &amp; 2 (Standalone)')
                 + (hasDedicatedIscsi ? ', iSCSI A &amp; B (Standalone)' : '')
                 + (backupEnabled ? ', In-Guest Backup (SET)' : '')
-                + (hasDedicatedIscsi ? '. Dedicated iSCSI adapters connect through leaf switch fabric to storage array.' : (hasSharedIscsi ? '. iSCSI shares cluster standalone NICs — traffic reaches storage array through leaf switch fabric.' : '. Storage adapters shown at bottom of each node.'))
+                + (hasDedicatedIscsi ? '. Dedicated iSCSI adapters connect through leaf switch fabric to storage array.' : (hasSharedIscsi ? '. iSCSI shares the standalone physical cluster NICs and uses per-target /32 routes through the leaf switch fabric.' : '. Storage adapters shown at bottom of each node.'))
                 + (totalNodes > 2 ? '<br><span style="color:var(--text-secondary);">Showing first 2 of ' + escapeHtml(String(totalNodes)) + ' nodes.</span>' : '')
                 + '</div>';
 
@@ -4881,7 +4874,7 @@
             svg += '</svg>';
 
             var note = '<div class="switchless-diagram__note">Note: Disaggregated ' + escapeHtml(storageLabel) + ' — Management + Compute intent (blue). '
-                + (hasSharedIscsi ? 'Standalone NICs (green) carry both CSV/Live Migration and iSCSI traffic on the same VLAN. iSCSI storage array is accessed through the leaf switch fabric (MPIO Active/Active, dual controllers). ' : 'Cluster networks are standalone NICs (green), one per leaf switch. ')
+                + (hasSharedIscsi ? 'Standalone physical NIC3/NIC4 (green) carry Cluster A/B and iSCSI Path A/B on the same VLAN/subnet/source IP. iSCSI target portal /32 routes are pinned to those physical adapters through the leaf switch fabric. ' : 'Cluster networks are standalone NICs (green), one per leaf switch. ')
                 + (hasDedicatedIscsi ? 'iSCSI uses dedicated standalone NICs (purple) connecting through leaf switches to the iSCSI storage array (MPIO Active/Active, dual controllers). ' : '')
                 + (hasFc ? 'FC HBA connects to separate SAN fabric (dedicated FC network, not through leaf switches). ' : '')
                 + (backupEnabled ? 'In-Guest Backup uses a Compute Intent (orange). ' : '')
@@ -7974,18 +7967,12 @@
             hostNetworkingRows += row('Cluster Network 2', 'Standalone, VLAN ' + clVlan2 + ' → Leaf-B');
 
             if (s.disaggStorageType === 'iscsi_4nic') {
-                hostNetworkingRows += row('iSCSI', 'Shared with Cluster standalone ports (same VLAN)');
+                hostNetworkingRows += row('iSCSI', 'Shared with physical NIC3/NIC4 Cluster paths (same VLAN/subnet/source IP)');
             } else if (s.disaggStorageType === 'iscsi_6nic') {
-                var iscsiA = (s.disaggVlans && s.disaggVlans.iscsiA) || '500';
-                var iscsiB = (s.disaggVlans && s.disaggVlans.iscsiB) || '600';
-                if (s.disaggBackupEnabled) {
-                    // 6-NIC + backup: iSCSI shares cluster ports (falls back), PCIe2 = backup
-                    hostNetworkingRows += row('iSCSI Mode', 'Shared with Cluster standalone ports');
-                } else {
-                    // 6-NIC no backup: dedicated iSCSI
-                    hostNetworkingRows += row('iSCSI Storage A', 'Standalone, VLAN ' + iscsiA + ' → Leaf-A');
-                    hostNetworkingRows += row('iSCSI Storage B', 'Standalone, VLAN ' + iscsiB + ' → Leaf-B');
-                }
+                var iscsiA = (s.disaggVlans && s.disaggVlans.iscsiA) || '300';
+                var iscsiB = (s.disaggVlans && s.disaggVlans.iscsiB) || '400';
+                hostNetworkingRows += row('iSCSI Storage A', 'Standalone, VLAN ' + iscsiA + ' → Leaf-A');
+                hostNetworkingRows += row('iSCSI Storage B', 'Standalone, VLAN ' + iscsiB + ' → Leaf-B');
             } else if (s.disaggStorageType === 'fc_san') {
                 hostNetworkingRows += row('FC SAN', 'FC HBA → Separate SAN Fabric (MPIO)');
             }

--- a/tests/index.html
+++ b/tests/index.html
@@ -92,7 +92,7 @@
 <body>
     <h1>🧪 Unit Tests - Azure Local Wizard</h1>
     <p>Comprehensive test suite for ODIN modular JavaScript functions</p>
-    
+
     <div id="summary" class="summary">
         <div class="summary-stat pass">
             <span class="number" id="pass-count">0</span>
@@ -107,9 +107,9 @@
             <span>Total</span>
         </div>
     </div>
-    
+
     <div id="test-results"></div>
-    
+
     <!-- Modular JavaScript files (load before main script.js) -->
     <script src="../js/utils.js"></script>
     <script src="../js/notifications.js"></script>
@@ -8027,6 +8027,120 @@
             return results;
         })());
 
+        testSuite('DA8: iSCSI 4-NIC uses physical NIC3/NIC4 shared paths', 'disaggregated.js', (() => {
+            var results = [];
+            var origState = JSON.parse(JSON.stringify(state));
+            var oldOverridesSection = document.getElementById('da8-intent-overrides');
+            var oldOverridesContainer = document.getElementById('da8-intent-overrides-container');
+            var oldDiagram = document.getElementById('da8-nic-layout-diagram');
+            var overridesSection = oldOverridesSection || document.createElement('div');
+            var overridesContainer = oldOverridesContainer || document.createElement('div');
+            var diagram = oldDiagram || document.createElement('div');
+            if (!oldOverridesSection) { overridesSection.id = 'da8-intent-overrides'; document.body.appendChild(overridesSection); }
+            if (!oldOverridesContainer) { overridesContainer.id = 'da8-intent-overrides-container'; document.body.appendChild(overridesContainer); }
+            if (!oldDiagram) { diagram.id = 'da8-nic-layout-diagram'; document.body.appendChild(diagram); }
+
+            Object.assign(state, {
+                architecture: 'disaggregated',
+                disaggStorageType: 'iscsi_4nic',
+                disaggBackupEnabled: false,
+                disaggPortCount: 4,
+                disaggVlans: { mgmt: 7, cluster1: 711, cluster2: 712, backup: 800 },
+                disaggSubnets: { cluster1: '10.71.1.0/24', cluster2: '10.71.2.0/24' },
+                disaggAdapterMapping: { ocp_p1: 'mgmt_compute', ocp_p2: 'mgmt_compute', pcie1_p1: 'cluster_1', pcie1_p2: 'cluster_2', bmc_p1: 'pool' },
+                disaggAdapterMappingConfirmed: true,
+                disaggIntentOverrides: { mgmt_compute: { rdmaMode: 'Disabled', jumboFrames: '1514', enableIov: '' } },
+                disaggOverridesConfirmed: false
+            });
+
+            try {
+                renderDisaggOverrides();
+                results.push(assert(overridesContainer.innerHTML.indexOf('iSCSI Network A') === -1,
+                    '4-NIC overrides do not show separate iSCSI Network A card', true,
+                    overridesContainer.innerHTML.indexOf('iSCSI Network A') === -1));
+                results.push(assert(overridesContainer.innerHTML.indexOf('Physical NIC3') !== -1,
+                    '4-NIC overrides describe physical NIC3 shared path', true,
+                    overridesContainer.innerHTML.indexOf('Physical NIC3') !== -1));
+
+                confirmDisaggOverrides();
+                var html = diagram.innerHTML;
+                results.push(assert(state.disaggOverridesConfirmed === true,
+                    '4-NIC confirm does not require separate iSCSI VLAN/subnet values', true,
+                    state.disaggOverridesConfirmed));
+                results.push(assert(html.indexOf('ClusterISCSISwitch') === -1,
+                    '4-NIC diagram excludes ClusterISCSISwitch', true,
+                    html.indexOf('ClusterISCSISwitch') === -1));
+                results.push(assert(html.indexOf('iSCSI1 vNIC') === -1 && html.indexOf('iSCSI2 vNIC') === -1,
+                    '4-NIC diagram excludes iSCSI host vNICs', true,
+                    html.indexOf('iSCSI1 vNIC') === -1 && html.indexOf('iSCSI2 vNIC') === -1));
+                results.push(assert(html.indexOf('NIC3 Path A') !== -1 && html.indexOf('NIC4 Path B') !== -1,
+                    '4-NIC diagram labels physical shared paths', true,
+                    html.indexOf('NIC3 Path A') !== -1 && html.indexOf('NIC4 Path B') !== -1));
+            } catch (err) {
+                results.push(assert(false, '4-NIC physical shared path rendering did not throw', 'no error', err.message));
+            }
+
+            if (!oldOverridesSection) overridesSection.remove();
+            if (!oldOverridesContainer) overridesContainer.remove();
+            if (!oldDiagram) diagram.remove();
+            Object.keys(state).forEach(function(k) { delete state[k]; });
+            Object.assign(state, origState);
+
+            return results;
+        })());
+
+        testSuite('DA8: iSCSI 6-NIC + Backup keeps dedicated iSCSI adapters', 'disaggregated.js', (() => {
+            var results = [];
+            var origState = JSON.parse(JSON.stringify(state));
+            var oldDiagram = document.getElementById('da8-nic-layout-diagram');
+            var diagram = oldDiagram || document.createElement('div');
+            if (!oldDiagram) { diagram.id = 'da8-nic-layout-diagram'; document.body.appendChild(diagram); }
+
+            Object.assign(state, {
+                architecture: 'disaggregated',
+                disaggStorageType: 'iscsi_6nic',
+                disaggBackupEnabled: true,
+                disaggPortCount: 6,
+                disaggVlans: { mgmt: 7, cluster1: 711, cluster2: 712, iscsiA: 300, iscsiB: 400, backup: 800 },
+                disaggSubnets: { cluster1: '10.71.1.0/24', cluster2: '10.71.2.0/24', iscsiA: '10.30.30.0/24', iscsiB: '10.40.40.0/24' },
+                disaggAdapterMapping: { ocp_p1: 'mgmt_compute', ocp_p2: 'mgmt_compute', pcie1_p1: 'cluster_1', pcie1_p2: 'cluster_2', pcie2_p1: 'iscsi_a', pcie2_p2: 'iscsi_b', bmc_p1: 'pool' },
+                disaggAdapterMappingConfirmed: true,
+                disaggOverridesConfirmed: true
+            });
+
+            try {
+                var slots = getDisaggNicSlots();
+                var slotLabels = slots.map(function(slot) { return slot.label; }).join('|');
+                var defaultMapping = getDisaggDefaultMapping();
+                renderDisaggHostNetworkingPreview();
+                var html = diagram.innerHTML;
+
+                results.push(assert(slotLabels.indexOf('PCIe2 (iSCSI Dedicated)') !== -1,
+                    '6-NIC + Backup labels PCIe2 as dedicated iSCSI', true,
+                    slotLabels.indexOf('PCIe2 (iSCSI Dedicated)') !== -1));
+                results.push(assert(slotLabels.indexOf('PCIe2 (Backup)') === -1,
+                    '6-NIC + Backup does not relabel PCIe2 as Backup', true,
+                    slotLabels.indexOf('PCIe2 (Backup)') === -1));
+                results.push(assert(defaultMapping.pcie2_p1 === 'iscsi_a' && defaultMapping.pcie2_p2 === 'iscsi_b',
+                    '6-NIC + Backup default mapping keeps NIC5/NIC6 on iSCSI', 'iscsi_a/iscsi_b',
+                    defaultMapping.pcie2_p1 + '/' + defaultMapping.pcie2_p2));
+                results.push(assert(html.indexOf('ClusterBackupSwitch') !== -1,
+                    '6-NIC + Backup diagram keeps ClusterBackupSwitch', true,
+                    html.indexOf('ClusterBackupSwitch') !== -1));
+                results.push(assert(html.indexOf('iSCSI Storage A') !== -1 && html.indexOf('iSCSI Storage B') !== -1,
+                    '6-NIC + Backup diagram keeps dedicated iSCSI groups', true,
+                    html.indexOf('iSCSI Storage A') !== -1 && html.indexOf('iSCSI Storage B') !== -1));
+            } catch (err) {
+                results.push(assert(false, '6-NIC + Backup dedicated iSCSI rendering did not throw', 'no error', err.message));
+            }
+
+            if (!oldDiagram) diagram.remove();
+            Object.keys(state).forEach(function(k) { delete state[k]; });
+            Object.assign(state, origState);
+
+            return results;
+        })());
+
         // ========================================================================
         // Phase 3: Disaggregated ARM generation — create-cluster-san template
         // ========================================================================
@@ -8070,7 +8184,7 @@
             state.disaggRackCount = 1;
             state.disaggNodesPerRack = 4;
             state.disaggSpineCount = 2;
-            state.disaggVlans = { mgmt: 7, cluster1: 711, cluster2: 712, iscsiA: 500, iscsiB: 600, backup: 800 };
+            state.disaggVlans = { mgmt: 7, cluster1: 711, cluster2: 712, iscsiA: 300, iscsiB: 400, backup: 800 };
             state.disaggVnis = { mgmt: 10007, cluster1: 10711, cluster2: 10712 };
             state.disaggMgmtVlanMode = 'access';
             state.disaggClusterVlanMode = { cluster1: 'access', cluster2: 'access' };


### PR DESCRIPTION
Summary: Updates the disaggregated iSCSI 4-NIC flow so NIC3/NIC4 render as physical shared Cluster+iSCSI paths with no ClusterISCSISwitch, SET, or host iSCSI vNICs. Keeps 6-NIC + Backup iSCSI dedicated on NIC5/NIC6, updates defaults/docs/changelog, and adds regression coverage. Validation: node scripts/run-tests.js passed 1041/1041; targeted lint/html validation passed during local verification.