### PR TITLE
Restore iSCSI 4-NIC preview labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+#### Disaggregated Storage-Type Preview Labels
+- **iSCSI 4-NIC preview status restored** - Added back the "Coming Soon" badge and "Feature not available yet" note on the DA1 iSCSI SAN (4-NIC) storage option.
+
 #### Knowledge Tab — Context-Aware Help Button
 - **Knowledge Help button now matches the active sub-page** (`js/script.js`, `js/nav.js`). The nav-bar Help button, when the Knowledge tab is active, now calls a new `showKnowledgeOnboarding()` that branches on which sidebar item is active: the **Architecture Guide** (same-origin `docs/outbound-connectivity/`) gets a 3-step overlay covering what the written reference covers, how to scroll through architectures, and how to find endpoint tables; **AzLoFlows** (cross-origin interactive diagram builder) gets a 3-step overlay covering what AzLoFlows is, how the embedded controls (Architecture bar, Resources bar, Traffic Types) work, and where to find the written reference.
 - **Root cause**: the two original same-origin flow-diagram pages (`azure-local-public-path-dark-flows.html`, `azure-local-private-path-dark-flows.html`) each defined a `showFlowOnboarding()` that `nav.js` probed via `iframe.contentWindow`. After the AzLoFlows integration replaced those pages with an external iframe, the `contentWindow` probe threw a `SecurityError` (cross-origin), the Architecture Guide had no such hook, and `showNavHelp()` silently fell through to the **Designer** onboarding walkthrough — unrelated to the Knowledge content on screen.

--- a/css/style.css
+++ b/css/style.css
@@ -1000,6 +1000,10 @@ header .header-description {
     z-index: 1;
 }
 
+.option-card.selected .coming-soon-badge {
+    right: 36px;
+}
+
 .option-card .preview-note {
     margin-top: 0.75rem;
     padding: 6px 10px;

--- a/index.html
+++ b/index.html
@@ -864,6 +864,7 @@
                             <p>Dedicated FC HBAs on separate fabric. FC traffic is isolated from Ethernet leaf switches.</p>
                         </div>
                         <div class="option-card" data-value="iscsi_4nic" onclick="selectDisaggOption('storageType', 'iscsi_4nic')">
+                            <span class="coming-soon-badge">Coming Soon</span>
                             <div class="icon">
                                 <svg aria-hidden="true" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                                     <rect x="3" y="3" width="18" height="18" rx="2" stroke-width="1.5" />
@@ -872,6 +873,7 @@
                             </div>
                             <h3>iSCSI SAN (4-NIC)</h3>
                             <p>NIC3/NIC4 stay physical: Cluster A/B and iSCSI Path A/B share the same adapters, VLANs, subnets, and source IPs. No SET or host vNICs.</p>
+                            <p class="preview-note">⚠️ Feature not available yet</p>
                         </div>
                         <div class="option-card" data-value="iscsi_6nic" onclick="selectDisaggOption('storageType', 'iscsi_6nic')">
                             <span class="coming-soon-badge">Coming Soon</span>


### PR DESCRIPTION
## Summary
- Restore the Coming Soon badge on the DA1 iSCSI SAN (4-NIC) option
- Restore the Feature not available yet note for the same card
- Move preview badges left on selected cards so they do not overlap the selected checkmark
- Add a changelog entry for the UI fix

## Validation
- npx html-validate index.html
- node scripts/run-tests.js (1041/1041 passed)