### PR TITLE
Fix AI-finding code-quality issues in run-tests.js and switch-config

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -7,7 +7,12 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 
-const outputFormat = process.argv.includes('--junit') ? 'junit' : 'nunit';
+const hasJunitFlag = process.argv.includes('--junit');
+const hasNunitFlag = process.argv.includes('--nunit');
+// When neither flag is passed, both reports are written by default. When a flag
+// is passed, only that format is written.
+const writeNunit = hasNunitFlag || (!hasJunitFlag && !hasNunitFlag);
+const writeJunit = hasJunitFlag || (!hasJunitFlag && !hasNunitFlag);
 
 // ---------------------------------------------------------------------------
 // Vendored-blob integrity pins (issue #230 — SheetJS for RVTools import).
@@ -352,14 +357,14 @@ function generateJUnitXML(results, passed, failed, total) {
         }
         
         // Generate and write XML reports
-        if (outputFormat === 'nunit' || !process.argv.includes('--junit')) {
+        if (writeNunit) {
             const nunitXml = generateNUnitXML(results.details, results.passed, results.failed, results.total);
             const nunitPath = path.join(resultsDir, 'nunit.xml');
             fs.writeFileSync(nunitPath, nunitXml);
             console.log(`NUnit XML report written to: ${nunitPath}`);
         }
         
-        if (outputFormat === 'junit' || !process.argv.includes('--nunit')) {
+        if (writeJunit) {
             const junitXml = generateJUnitXML(results.details, results.passed, results.failed, results.total);
             const junitPath = path.join(resultsDir, 'junit.xml');
             fs.writeFileSync(junitPath, junitXml);

--- a/switch-config/index.html
+++ b/switch-config/index.html
@@ -136,7 +136,7 @@
                 <span class="sc-icon">🔌</span>
                 <span>
                     <strong>Disaggregated deployment — Leaf (ToR) switch scope only.</strong>
-                    This generator produces leaf switches configuration only.
+                    This generator produces leaf switch configuration only.
                     It does <strong>NOT</strong> generate configuration for the spine or service-leaf switches.
                     The SAN fibre-channel zoning, and array host registrations configuration is not in scope — configure these using your SAN fabric controller / SAN management tool before running Validate.
                 </span>
@@ -152,7 +152,7 @@
                     <div class="sc-field">
                         <label for="sc-tor-model"><abbr title="Top of Rack">ToR</abbr> Switch Model</label>
                         <select id="sc-tor-model">
-                            <option value="">-- Select TOR Model --</option>
+                            <option value="">-- Select ToR Model --</option>
                         </select>
                     </div>
                     <div class="sc-field">
@@ -808,6 +808,10 @@
         </section>
     </div>
 
+    <footer style="text-align:center;padding:2rem 1rem 1rem;font-size:0.85rem;color:#aaa;">
+        🔒 Privacy: The data shown in this report is stored locally in your web browser. No data or template input values are transmitted externally.
+    </footer>
+
     <!-- Scripts (order matters: models → builder → templates → qos-audit → main) -->
     <script src="../js/utils.js"></script>
     <script src="../js/changelog.js"></script>
@@ -819,9 +823,6 @@
     <script src="templates/dell-os10.js"></script>
     <script src="qos-audit.js"></script>
     <script src="switch-config.js"></script>
-    <footer style="text-align:center;padding:2rem 1rem 1rem;font-size:0.85rem;color:#aaa;">
-        🔒 Privacy: The data shown in this report is stored locally in your web browser. No data or template input values are transmitted externally.
-    </footer>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

Addresses the 5 GitHub AI code-quality findings across two recently-changed files. No user-visible behaviour change, so no version bump.

### `scripts/run-tests.js`
- Replaced the confusing `outputFormat === 'nunit' || !process.argv.includes('--junit')` conditions with explicit `writeNunit` / `writeJunit` flags and a comment documenting the intent: **both** reports are written by default when no flag is passed, and only the named format is written when `--nunit` or `--junit` is given.
- Removed the now-unused `outputFormat` variable.

### `switch-config/index.html`
- Grammar: "produces leaf switches configuration only" → "produces leaf switch configuration only".
- Casing: "Select TOR Model" → "Select ToR Model" (matches the consistent `ToR` casing used elsewhere).
- Moved the `<footer>` out from after the `<script>` tags to its proper place after the visible content and before the scripts.

## Validation
- `node scripts/run-tests.js` → **1318/1318 passed**; both `nunit.xml` and `junit.xml` written correctly (default no-flag path).
- `npx html-validate switch-config/index.html` → clean.
