### PR TITLE
Sizer: per-node heading shows node count and overcommit ratio

### DIFF
--- a/sizer/index.html
+++ b/sizer/index.html
@@ -677,7 +677,7 @@
                 <!-- Per-Node Requirements -->
                 <div class="per-node-section">
                     <h3 id="per-node-title">Nodes Hardware Requirements:</h3>
-                    <p class="per-node-subtitle" id="per-node-subtitle">- includes N+1 nodes (for HA and update resiliency), compute uses a <a href="#vcpu-ratio" class="per-node-ratio-link" onclick="document.getElementById('vcpu-ratio').scrollIntoView({behavior:'smooth',block:'center'});document.getElementById('vcpu-ratio').focus();return false;">4:1 vCPU overcommit ratio</a></p>
+                    <p class="per-node-subtitle" id="per-node-subtitle">- includes N+1 nodes (for HA and update resiliency), compute uses a <a href="#vcpu-ratio" class="per-node-ratio-link" onclick="document.getElementById('vcpu-ratio').scrollIntoView({behavior:'smooth',block:'center'});document.getElementById('vcpu-ratio').focus();return false;">4:1 vCPU overcommit ratio</a> &middot; <a href="#" class="per-node-ratio-link" onclick="showHardwareWeightingInfo(); return false;" title="How the auto-scaler picks node count, memory, ratio, and cluster type">how is this calculated?</a></p>
                     <div class="per-node-grid">
                         <div class="per-node-item">
                             <span class="label">Physical Cores</span>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -676,7 +676,7 @@
 
                 <!-- Per-Node Requirements -->
                 <div class="per-node-section">
-                    <h3 id="per-node-title">Workload Per-Node Requirements (with N+1)</h3>
+                    <h3 id="per-node-title">Nodes Hardware Requirements (with N+1)</h3>
                     <div class="per-node-grid">
                         <div class="per-node-item">
                             <span class="label">Physical Cores</span>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -678,7 +678,7 @@
                 <div class="per-node-section">
                     <h3 id="per-node-title">Nodes Hardware Requirements:</h3>
                     <p class="per-node-subtitle" id="per-node-subtitle">- includes N+1 nodes (for HA and update resiliency), compute uses a <a href="#vcpu-ratio" class="per-node-ratio-link" onclick="document.getElementById('vcpu-ratio').scrollIntoView({behavior:'smooth',block:'center'});document.getElementById('vcpu-ratio').focus();return false;">4:1 vCPU overcommit ratio</a></p>
-                    <p class="per-node-subtitle" id="per-node-howcalc"><a href="#" class="per-node-ratio-link" onclick="showHardwareWeightingInfo(); return false;" title="How the auto-scaler picks node count, memory, ratio, and cluster type">how is this calculated?</a></p>
+                    <p class="per-node-subtitle" id="per-node-howcalc"><a href="#" class="per-node-ratio-link" onclick="showHardwareWeightingInfo(); return false;" title="How the auto-scaler picks node count, memory, ratio, and cluster type">How is this calculated?</a></p>
                     <div class="per-node-grid">
                         <div class="per-node-item">
                             <span class="label">Physical Cores</span>
@@ -1166,6 +1166,8 @@
                 <strong style="color: var(--accent-blue); font-size: 13px;">💡 You are always in control.</strong>
                 <p style="margin: 6px 0 0 0; color: var(--text-primary); font-size: 13px; line-height: 1.5;">Every auto-decision is advisory. If you have a fixed requirement &mdash; a specific node count, a specific memory size per node, a specific CPU SKU, or a specific vCPU:core ratio &mdash; just set it manually. As soon as you change a field, the Sizer locks that choice and the auto-scaler respects it for all future workload changes.</p>
             </div>
+
+            <p style="margin: 12px 0 0 0; color: var(--text-secondary); font-size: 12px;">Have a question or feedback? Please raise an <a href="https://github.com/Azure/odinforazurelocal/issues" target="_blank" rel="noopener noreferrer" style="color: var(--accent-blue); text-decoration: none;">Issue in GitHub</a>.</p>
 
             <div style="text-align: right; margin-top: 16px;">
                 <button onclick="closeHardwareWeightingInfo()" class="onboarding-btn onboarding-btn-primary">Got it</button>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -676,7 +676,8 @@
 
                 <!-- Per-Node Requirements -->
                 <div class="per-node-section">
-                    <h3 id="per-node-title">Nodes Hardware Requirements (with N+1)</h3>
+                    <h3 id="per-node-title">Nodes Hardware Requirements:</h3>
+                    <p class="per-node-subtitle" id="per-node-subtitle">- includes N+1 nodes (for HA and update resiliency) and compute using a <a href="#vcpu-ratio" class="per-node-ratio-link" onclick="document.getElementById('vcpu-ratio').scrollIntoView({behavior:'smooth',block:'center'});document.getElementById('vcpu-ratio').focus();return false;">4:1 vCPU overcommit ratio</a></p>
                     <div class="per-node-grid">
                         <div class="per-node-item">
                             <span class="label">Physical Cores</span>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -677,7 +677,8 @@
                 <!-- Per-Node Requirements -->
                 <div class="per-node-section">
                     <h3 id="per-node-title">Nodes Hardware Requirements:</h3>
-                    <p class="per-node-subtitle" id="per-node-subtitle">- includes N+1 nodes (for HA and update resiliency), compute uses a <a href="#vcpu-ratio" class="per-node-ratio-link" onclick="document.getElementById('vcpu-ratio').scrollIntoView({behavior:'smooth',block:'center'});document.getElementById('vcpu-ratio').focus();return false;">4:1 vCPU overcommit ratio</a> &middot; <a href="#" class="per-node-ratio-link" onclick="showHardwareWeightingInfo(); return false;" title="How the auto-scaler picks node count, memory, ratio, and cluster type">how is this calculated?</a></p>
+                    <p class="per-node-subtitle" id="per-node-subtitle">- includes N+1 nodes (for HA and update resiliency), compute uses a <a href="#vcpu-ratio" class="per-node-ratio-link" onclick="document.getElementById('vcpu-ratio').scrollIntoView({behavior:'smooth',block:'center'});document.getElementById('vcpu-ratio').focus();return false;">4:1 vCPU overcommit ratio</a></p>
+                    <p class="per-node-subtitle" id="per-node-howcalc"><a href="#" class="per-node-ratio-link" onclick="showHardwareWeightingInfo(); return false;" title="How the auto-scaler picks node count, memory, ratio, and cluster type">how is this calculated?</a></p>
                     <div class="per-node-grid">
                         <div class="per-node-item">
                             <span class="label">Physical Cores</span>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -677,7 +677,7 @@
                 <!-- Per-Node Requirements -->
                 <div class="per-node-section">
                     <h3 id="per-node-title">Nodes Hardware Requirements:</h3>
-                    <p class="per-node-subtitle" id="per-node-subtitle">- includes N+1 nodes (for HA and update resiliency) and compute using a <a href="#vcpu-ratio" class="per-node-ratio-link" onclick="document.getElementById('vcpu-ratio').scrollIntoView({behavior:'smooth',block:'center'});document.getElementById('vcpu-ratio').focus();return false;">4:1 vCPU overcommit ratio</a></p>
+                    <p class="per-node-subtitle" id="per-node-subtitle">- includes N+1 nodes (for HA and update resiliency), compute uses a <a href="#vcpu-ratio" class="per-node-ratio-link" onclick="document.getElementById('vcpu-ratio').scrollIntoView({behavior:'smooth',block:'center'});document.getElementById('vcpu-ratio').focus();return false;">4:1 vCPU overcommit ratio</a></p>
                     <div class="per-node-grid">
                         <div class="per-node-item">
                             <span class="label">Physical Cores</span>

--- a/sizer/index.html
+++ b/sizer/index.html
@@ -887,6 +887,9 @@
                     <button class="btn btn-secondary" onclick="importSizerJSON()" title="Import configuration from a JSON file">
                         📂 Import JSON
                     </button>
+                    <button class="btn btn-secondary" onclick="openImportModal('rvtools')" title="Import your VMware inventory from an RVTools Excel export">
+                        📊 RVTools
+                    </button>
                 </div>
             </div>
         </div>

--- a/sizer/sizer.css
+++ b/sizer/sizer.css
@@ -1204,8 +1204,26 @@ header .header-description {
 .per-node-section h3 {
     font-size: 14px;
     font-weight: 600;
-    margin-bottom: 16px;
+    margin-bottom: 4px;
     color: var(--text-secondary);
+}
+
+.per-node-subtitle {
+    font-size: 12px;
+    font-weight: 400;
+    color: var(--text-secondary);
+    margin: 0 0 16px;
+    opacity: 0.85;
+}
+
+.per-node-subtitle .per-node-ratio-link {
+    color: var(--accent-blue);
+    text-decoration: none;
+}
+
+.per-node-subtitle .per-node-ratio-link:hover,
+.per-node-subtitle .per-node-ratio-link:focus {
+    text-decoration: underline;
 }
 
 .per-node-grid {

--- a/sizer/sizer.css
+++ b/sizer/sizer.css
@@ -1216,6 +1216,10 @@ header .header-description {
     opacity: 0.85;
 }
 
+.per-node-subtitle + .per-node-subtitle {
+    margin-top: -12px;
+}
+
 .per-node-subtitle .per-node-ratio-link {
     color: var(--accent-blue);
     text-decoration: none;

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -5691,7 +5691,7 @@ function calculateRequirements(options) {
         }
         var perNodeSubtitleEl = document.getElementById('per-node-subtitle');
         if (perNodeSubtitleEl) {
-            perNodeSubtitleEl.innerHTML = '- includes N+1 nodes (for HA and update resiliency) and compute using a '
+            perNodeSubtitleEl.innerHTML = '- includes N+1 nodes (for HA and update resiliency), compute uses a '
                 + '<a href="#vcpu-ratio" class="per-node-ratio-link" '
                 + 'onclick="document.getElementById(\'vcpu-ratio\').scrollIntoView({behavior:\'smooth\',block:\'center\'});'
                 + 'document.getElementById(\'vcpu-ratio\').focus();return false;">'
@@ -7088,7 +7088,7 @@ function exportSizerWord() {
 
     // Per-Node Requirements
     html += '<h3>' + nodeCount + ' x Nodes Hardware Requirements:</h3>';
-    html += '<p style="font-size:10pt; color:#555; margin:0 0 8pt;">- includes N+1 nodes (for HA and update resiliency) and compute using a ' + getVcpuRatio() + ':1 vCPU overcommit ratio</p>';
+    html += '<p style="font-size:10pt; color:#555; margin:0 0 8pt;">- includes N+1 nodes (for HA and update resiliency), compute uses a ' + getVcpuRatio() + ':1 vCPU overcommit ratio</p>';
     html += '<table class="kv-table"><tbody>';
     html += '<tr><td>Physical Cores</td><td>' + perNodeCores + '</td></tr>';
     html += '<tr><td>Memory</td><td>' + perNodeMemory + '</td></tr>';

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -5695,12 +5695,7 @@ function calculateRequirements(options) {
                 + '<a href="#vcpu-ratio" class="per-node-ratio-link" '
                 + 'onclick="document.getElementById(\'vcpu-ratio\').scrollIntoView({behavior:\'smooth\',block:\'center\'});'
                 + 'document.getElementById(\'vcpu-ratio\').focus();return false;">'
-                + getVcpuRatio() + ':1 vCPU overcommit ratio</a>'
-                + ' &middot; '
-                + '<a href="#" class="per-node-ratio-link" '
-                + 'onclick="showHardwareWeightingInfo(); return false;" '
-                + 'title="How the auto-scaler picks node count, memory, ratio, and cluster type">'
-                + 'how is this calculated?</a>';
+                + getVcpuRatio() + ':1 vCPU overcommit ratio</a>';
         }
 
         // For disaggregated, show SAN storage requirement instead of per-node raw/usable

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -5684,10 +5684,10 @@ function calculateRequirements(options) {
         document.getElementById('per-node-cores').textContent = perNodeCores || 0;
         document.getElementById('per-node-memory').textContent = (perNodeMemory || 0) + ' GB';
 
-        // Reflect the current vCPU overcommit ratio in the per-node heading
+        // Reflect the current node count and vCPU overcommit ratio in the per-node heading
         var perNodeTitleEl = document.getElementById('per-node-title');
         if (perNodeTitleEl) {
-            perNodeTitleEl.textContent = 'Workload Per-Node Requirements (with N+1) and ' + getVcpuRatio() + ':1 vCPU Overcommit Ratio';
+            perNodeTitleEl.textContent = nodeCount + ' x Nodes Hardware Requirements (with N+1) using ' + getVcpuRatio() + ':1 vCPU Overcommit Ratio';
         }
 
         // For disaggregated, show SAN storage requirement instead of per-node raw/usable
@@ -7079,7 +7079,7 @@ function exportSizerWord() {
     html += '</div>';
 
     // Per-Node Requirements
-    html += '<h3>Workload Per-Node Requirements (with N+1) and ' + getVcpuRatio() + ':1 vCPU Overcommit Ratio</h3>';
+    html += '<h3>' + nodeCount + ' x Nodes Hardware Requirements (with N+1) using ' + getVcpuRatio() + ':1 vCPU Overcommit Ratio</h3>';
     html += '<table class="kv-table"><tbody>';
     html += '<tr><td>Physical Cores</td><td>' + perNodeCores + '</td></tr>';
     html += '<tr><td>Memory</td><td>' + perNodeMemory + '</td></tr>';

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -5695,7 +5695,12 @@ function calculateRequirements(options) {
                 + '<a href="#vcpu-ratio" class="per-node-ratio-link" '
                 + 'onclick="document.getElementById(\'vcpu-ratio\').scrollIntoView({behavior:\'smooth\',block:\'center\'});'
                 + 'document.getElementById(\'vcpu-ratio\').focus();return false;">'
-                + getVcpuRatio() + ':1 vCPU overcommit ratio</a>';
+                + getVcpuRatio() + ':1 vCPU overcommit ratio</a>'
+                + ' &middot; '
+                + '<a href="#" class="per-node-ratio-link" '
+                + 'onclick="showHardwareWeightingInfo(); return false;" '
+                + 'title="How the auto-scaler picks node count, memory, ratio, and cluster type">'
+                + 'how is this calculated?</a>';
         }
 
         // For disaggregated, show SAN storage requirement instead of per-node raw/usable

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -5687,7 +5687,15 @@ function calculateRequirements(options) {
         // Reflect the current node count and vCPU overcommit ratio in the per-node heading
         var perNodeTitleEl = document.getElementById('per-node-title');
         if (perNodeTitleEl) {
-            perNodeTitleEl.textContent = nodeCount + ' x Nodes Hardware Requirements (with N+1) using ' + getVcpuRatio() + ':1 vCPU Overcommit Ratio';
+            perNodeTitleEl.textContent = nodeCount + ' x Nodes Hardware Requirements:';
+        }
+        var perNodeSubtitleEl = document.getElementById('per-node-subtitle');
+        if (perNodeSubtitleEl) {
+            perNodeSubtitleEl.innerHTML = '- includes N+1 nodes (for HA and update resiliency) and compute using a '
+                + '<a href="#vcpu-ratio" class="per-node-ratio-link" '
+                + 'onclick="document.getElementById(\'vcpu-ratio\').scrollIntoView({behavior:\'smooth\',block:\'center\'});'
+                + 'document.getElementById(\'vcpu-ratio\').focus();return false;">'
+                + getVcpuRatio() + ':1 vCPU overcommit ratio</a>';
         }
 
         // For disaggregated, show SAN storage requirement instead of per-node raw/usable
@@ -7079,7 +7087,8 @@ function exportSizerWord() {
     html += '</div>';
 
     // Per-Node Requirements
-    html += '<h3>' + nodeCount + ' x Nodes Hardware Requirements (with N+1) using ' + getVcpuRatio() + ':1 vCPU Overcommit Ratio</h3>';
+    html += '<h3>' + nodeCount + ' x Nodes Hardware Requirements:</h3>';
+    html += '<p style="font-size:10pt; color:#555; margin:0 0 8pt;">- includes N+1 nodes (for HA and update resiliency) and compute using a ' + getVcpuRatio() + ':1 vCPU overcommit ratio</p>';
     html += '<table class="kv-table"><tbody>';
     html += '<tr><td>Physical Cores</td><td>' + perNodeCores + '</td></tr>';
     html += '<tr><td>Memory</td><td>' + perNodeMemory + '</td></tr>';

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -7699,7 +7699,9 @@ function shareSizerURL() { // eslint-disable-line no-unused-vars
         return;
     }
     try {
-        var shareName = prompt('Enter a name for this configuration (optional):', '');
+        var clusterNameEl = document.getElementById('cluster-name');
+        var defaultName = (clusterNameEl && clusterNameEl.value ? clusterNameEl.value.trim() : '').substring(0, 100);
+        var shareName = prompt('Enter a name for this configuration (optional):', defaultName);
         if (shareName === null) return; // User cancelled
 
         var state = getSizerState();


### PR DESCRIPTION
﻿Updates the Sizer's per-node hardware requirements heading, the weighting-info popup, the Share URL prompt, and the export-actions footer.

**Heading - before:**
Workload Per-Node Requirements (with N+1) and X:1 vCPU Overcommit Ratio`

**Heading - after (renders as three lines):**
- **NN x Nodes Hardware Requirements:**
- *- includes N+1 nodes (for HA and update resiliency), compute uses a [X:1 vCPU overcommit ratio](#vcpu-ratio)*
- *[How is this calculated?](#)*

Where NN is the current node count and X is the current vCPU overcommit ratio (both update live).

**Changes:**
- Dynamic per-node heading: shows current node count and overcommit ratio.
- New subtitle (smaller 12px, secondary color) clarifies N+1 + ratio in one line.
- X:1 vCPU overcommit ratio is a blue link that smooth-scrolls to and focuses the #vcpu-ratio dropdown in Advanced Settings.
- How is this calculated? link on its own line opens the existing *Sizer hardware scaling weighting logic* popup (same popup as the link in the hardware config panel).
- Weighting-info popup now includes a footer line: *Have a question or feedback? Please raise an [Issue in GitHub](https://github.com/Azure/odinforazurelocal/issues).*
- **Share URL prompt** now pre-populates with the current Cluster Name field value (truncated to 100 chars) so users don't retype it.
- **RVTools button** added to the export-actions footer row (matches the existing toolbar button; opens the import modal directly on the RVTools tab).
- Same two-line heading mirrored in the Word/HTML report export (plain text, no link).
- Static placeholder in sizer/index.html updated for consistency before first calc.

No functional/calculation changes. No version bump or changelog entry (per request).

**Validation:** 1325/1325 tests pass; 0 ESLint errors; html-validate clean.
