### PR TITLE
switch-config/dell-os10: allow VLT MAC override via data.vlt.mac + placeholder warning comment

### DIFF
--- a/switch-config/templates/dell-os10.js
+++ b/switch-config/templates/dell-os10.js
@@ -476,15 +476,20 @@
         }
 
         const priority = (data.switch && data.switch.type === 'TOR1') ? 1 : 2;
+        const defaultVltMac = 'de:ad:00:be:ef:01';
+        const vltMac = (data.vlt && data.vlt.mac) ? data.vlt.mac : defaultVltMac;
 
         const lines = [];
         lines.push('! vlt.j2');
+        if (vltMac === defaultVltMac) {
+            lines.push('! NOTE: vlt-mac below is a placeholder and MUST be unique per VLT domain — change before deploying to avoid VLT instability when multiple pairs share a fabric');
+        }
         lines.push('vlt-domain 1');
         lines.push('  backup destination ' + ibgpPeerIp);
         lines.push('  discovery-interface ' + mlagRange);
         lines.push('  peer-routing');
         lines.push('  primary-priority ' + priority);
-        lines.push('  vlt-mac de:ad:00:be:ef:01');
+        lines.push('  vlt-mac ' + vltMac);
         return lines.join('\n');
     };
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -7678,6 +7678,38 @@
             return results;
         })());
 
+        testSuite('Dell OS10: renderVlt VLT MAC override + placeholder warning', 'dell-os10.js', (() => {
+            const results = [];
+            const baseData = {
+                switch: { type: 'TOR1' },
+                interfaces: [{ type: 'MLAG', start_intf: '1/1/55', end_intf: '1/1/56' }],
+                bgp: { neighbors: [{ description: 'iBGP_PEER', ip: '10.0.0.18', remote_as: 65001 }] }
+            };
+            const defaultOut = DellOs10Renderer.renderVlt(baseData);
+
+            results.push(assert(defaultOut.indexOf('vlt-mac de:ad:00:be:ef:01') !== -1,
+                'Default placeholder MAC is rendered when data.vlt.mac is absent', true,
+                defaultOut.indexOf('vlt-mac de:ad:00:be:ef:01') !== -1));
+            results.push(assert(defaultOut.indexOf('! NOTE: vlt-mac below is a placeholder') !== -1,
+                'Warning comment is prepended when the default placeholder MAC is used', true,
+                defaultOut.indexOf('! NOTE: vlt-mac below is a placeholder') !== -1));
+
+            const overrideData = Object.assign({}, baseData, { vlt: { mac: 'aa:bb:cc:dd:ee:01' } });
+            const overrideOut = DellOs10Renderer.renderVlt(overrideData);
+
+            results.push(assert(overrideOut.indexOf('vlt-mac aa:bb:cc:dd:ee:01') !== -1,
+                'Override via data.vlt.mac is rendered when provided', true,
+                overrideOut.indexOf('vlt-mac aa:bb:cc:dd:ee:01') !== -1));
+            results.push(assert(overrideOut.indexOf('vlt-mac de:ad:00:be:ef:01') === -1,
+                'Default placeholder MAC is NOT rendered when override is provided', true,
+                overrideOut.indexOf('vlt-mac de:ad:00:be:ef:01') === -1));
+            results.push(assert(overrideOut.indexOf('! NOTE: vlt-mac below is a placeholder') === -1,
+                'Warning comment is suppressed when an override is provided', true,
+                overrideOut.indexOf('! NOTE: vlt-mac below is a placeholder') === -1));
+
+            return results;
+        })());
+
         testSuite('Dell OS10: renderFullConfig end-to-end', 'dell-os10.js', (() => {
             const results = [];
             const b = new SwitchConfigBuilder({


### PR DESCRIPTION
## Summary

Address PR review feedback on `switch-config/templates/dell-os10.js`: the VLT MAC `de:ad:00:be:ef:01` was hard-coded into every generated Dell OS10 VLT config. If two pairs of switches generated from this template end up sharing a fabric without the operator changing the value, both VLT domains would advertise the same MAC and cause VLT instability.

## Why

The reviewer flagged the hard-coded MAC and suggested two things:
1. Make it overridable from caller data
2. At minimum, document that it must be changed before deploying

The first half on its own is too subtle — a customer who blindly accepts the generated config still ends up with the placeholder. The fix here does **both**: accepts an override **and** emits a warning comment in the rendered config when the placeholder is still in use, so the operator sees it during config review.

The other finding in the same review (extracting `pc.id === 102` into a `VLT_PEER_LINK_PC_ID` constant) was not actioned — `102` is already a project-wide convention seeded in `switch-config/models.js` (4 locations), the existing line is belt-and-suspenders (id OR description check), and a single-use named constant runs counter to the repo's "no abstractions for single-use code" rule. Reply on the review thread covers the reasoning.

## What changed

### `switch-config/templates/dell-os10.js` — `renderVlt()`

```diff
 const priority = (data.switch && data.switch.type === 'TOR1') ? 1 : 2;
+const defaultVltMac = 'de:ad:00:be:ef:01';
+const vltMac = (data.vlt && data.vlt.mac) ? data.vlt.mac : defaultVltMac;

 const lines = [];
 lines.push('! vlt.j2');
+if (vltMac === defaultVltMac) {
+    lines.push('! NOTE: vlt-mac below is a placeholder and MUST be unique per VLT domain — change before deploying to avoid VLT instability when multiple pairs share a fabric');
+}
 lines.push('vlt-domain 1');
 ...
-lines.push('  vlt-mac de:ad:00:be:ef:01');
+lines.push('  vlt-mac ' + vltMac);
```

- Backwards-compatible: when `data.vlt.mac` is absent the rendered MAC is unchanged from before, and any caller / fixture / saved config that doesn't pass `data.vlt` continues to work.
- The warning comment is **only** emitted when the placeholder is in use, so an operator who has supplied a real MAC sees a clean config with no nag.

### `tests/index.html` — new `Dell OS10: renderVlt VLT MAC override + placeholder warning` suite (5 assertions)

Covers:
- Default placeholder MAC rendered when `data.vlt.mac` is absent
- Warning comment prepended when the default placeholder is used
- Override via `data.vlt.mac` is rendered when provided
- Default placeholder is NOT rendered when override is provided
- Warning comment is suppressed when override is provided

## Validation

- `npx eslint "switch-config/templates/dell-os10.js"` → 0 errors
- `npx html-validate "tests/index.html"` → clean
- `node scripts/run-tests.js` → **1397 / 1397 passed** (was 1392; +5 from the new suite)

## Notes for reviewer

- No release notes (no user-visible change to the wizard / sizer; only a generated-config polish in the switch-config templates).
- No version bump (same reason).
- No new external dependencies or network calls.
- Manual merge per repo policy after checks pass.
