### PR TITLE
sizer: include annualKwh in sizerHardware.power payload + render Total Annual Energy in report and PPT

### DIFF
--- a/report/pptx-export.js
+++ b/report/pptx-export.js
@@ -1650,6 +1650,16 @@
             text: 'Heat output: ' + (pw.totalBtu || 0).toLocaleString() + ' BTU/hr',
             lvl: 1
         });
+        if (pw.annualKwh != null && isFinite(pw.annualKwh)) {
+            const kwh = pw.annualKwh;
+            const energyText = (kwh >= 1000000)
+                ? (kwh / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 }) + ' MWh/yr'
+                : Math.round(kwh).toLocaleString() + ' kWh/yr';
+            bullets.push({
+                text: 'Total annual energy: ' + energyText + ' (24/7/365 at total instance power)',
+                lvl: 1
+            });
+        }
         if (pw.rackUnits) {
             bullets.push({
                 text: 'Rack space: ' + pw.rackUnits + 'U',

--- a/report/report.js
+++ b/report/report.js
@@ -8235,6 +8235,13 @@
             sizerPowerRows += row('Per-Node Power (est.)', (pw.perNodeW || 0).toLocaleString() + ' Watts');
             sizerPowerRows += row('Total Instance Power (est.)', (pw.totalW || 0).toLocaleString() + ' Watts');
             sizerPowerRows += row('Heat Output (est.)', (pw.totalBtu || 0).toLocaleString() + ' BTU/hr');
+            if (pw.annualKwh != null && isFinite(pw.annualKwh)) {
+                const kwh = pw.annualKwh;
+                const energyText = (kwh >= 1000000)
+                    ? (kwh / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 }) + ' MWh/yr'
+                    : Math.round(kwh).toLocaleString() + ' kWh/yr';
+                sizerPowerRows += row('Total Annual Energy (est.)', energyText);
+            }
             if (pw.rackUnits) {
                 sizerPowerRows += row('Rack Units (est.)', pw.rackUnits + 'U');
             }

--- a/sizer/sizer.js
+++ b/sizer/sizer.js
@@ -8044,6 +8044,7 @@ function selectRegionAndConfigure(region, cloud) {
                 perNodeW: _lastPowerEstimate.perNodeW,
                 totalW: _lastPowerEstimate.totalW,
                 totalBtu: _lastPowerEstimate.totalBtu,
+                annualKwh: _lastPowerEstimate.annualKwh,
                 rackUnits: _lastPowerEstimate.rackUnits,
                 infraPowerW: _lastPowerEstimate.infraPowerW,
                 infraPowerNote: _lastPowerEstimate.infraPowerNote,

--- a/tests/index.html
+++ b/tests/index.html
@@ -3460,6 +3460,35 @@
                 'NaN → em-dash', '\u2014', formatAnnualEnergy(NaN))
         ]);
 
+        // --- sizerHardware.power.annualKwh → report.js + pptx-export.js inline formatter ---
+        // report.js and pptx-export.js can't import sizer.js's formatAnnualEnergy
+        // helper (report page doesn't load sizer.js), so they each carry a copy
+        // of the same kWh→MWh threshold logic. This suite verifies that inline
+        // copy matches the canonical formatter for the values we care about.
+        // If formatAnnualEnergy() changes, the inline copies in report.js and
+        // pptx-export.js must be updated to match — and these assertions will
+        // fail until they are.
+        function _inlineAnnualEnergy(kwh) {
+            if (kwh == null || !isFinite(kwh)) return null;
+            return (kwh >= 1000000)
+                ? (kwh / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 }) + ' MWh/yr'
+                : Math.round(kwh).toLocaleString() + ' kWh/yr';
+        }
+        testSuite('sizerHardware.power.annualKwh inline formatter parity', 'report.js + pptx-export.js', [
+            assert(_inlineAnnualEnergy(160571) === formatAnnualEnergy(160571),
+                'kWh below threshold matches canonical', formatAnnualEnergy(160571), _inlineAnnualEnergy(160571)),
+            assert(_inlineAnnualEnergy(999999) === formatAnnualEnergy(999999),
+                'just below 1 M kWh matches canonical', formatAnnualEnergy(999999), _inlineAnnualEnergy(999999)),
+            assert(_inlineAnnualEnergy(1000000) === formatAnnualEnergy(1000000),
+                'at 1 M kWh threshold matches canonical', formatAnnualEnergy(1000000), _inlineAnnualEnergy(1000000)),
+            assert(_inlineAnnualEnergy(1605710) === formatAnnualEnergy(1605710),
+                'scale-out MWh value matches canonical', formatAnnualEnergy(1605710), _inlineAnnualEnergy(1605710)),
+            assert(_inlineAnnualEnergy(null) === null,
+                'null → null (caller guards with `pw.annualKwh != null`)', null, _inlineAnnualEnergy(null)),
+            assert(_inlineAnnualEnergy(NaN) === null,
+                'NaN → null (caller skips the row/bullet)', null, _inlineAnnualEnergy(NaN))
+        ]);
+
         // --- getGrowthYears() + getGrowthFactor() (DOM-backed, issue #254) ---
         // The 5-year No/Yes dropdown drives both helpers; we flip its value to
         // cover both modes.


### PR DESCRIPTION
## Summary

Carries `annualKwh` from the Sizer's Power & Heat panel through to the Designer
state, the Configuration Report, and the Power & Heat PPT slide — so the
"Estimated Power, Heat & Rack Space" view stays consistent across all three
surfaces. Previously the Sizer panel showed annual energy locally but it was
dropped when the payload was handed off to the Designer.

## Changes

- **`sizer/sizer.js`** — add `annualKwh` to the `sizerHardware.power` object
  built in `getSizerState()`. Source value already existed on
  `_lastPowerEstimate.annualKwh` (computed by `calculateRequirements()`).
- **`report/report.js`** — render a new `Total Annual Energy (est.)` row in the
  Power, Heat & Rack Space table when `pw.annualKwh` is present. Inline kWh →
  MWh auto-scaling at the 1,000,000 kWh boundary (matches
  `formatAnnualEnergy()` in `sizer.js`).
- **`report/pptx-export.js`** — emit a `Total annual energy: …` bullet on the
  Power & Heat slide, same threshold logic, only when `pw.annualKwh` is set.
- **`tests/index.html`** — 6 new assertions verifying the inline formatter in
  report.js/pptx-export.js produces the same string as the canonical
  `formatAnnualEnergy()` for the values we care about (sub-1 M kWh, threshold,
  scale-out MWh, null/NaN guards).

## Test count

- Before: 1392 / 1392
- After: **1398 / 1398** (+6)

## Schema risk

None. The published JSON schemas only cover top-level `sizerState` keys; the
nested `sizerHardware.power` sub-object isn't part of the schema contract, so
adding a field is purely additive and `additionalProperties: true` already
allows it on import. Schema-drift checks all green.

## Validation

```
✅ Schema drift OK: Designer (100 fields in sync)
✅ Schema drift OK: Sizer (42 fields in sync)
✅ Schema drift OK: Sizer workload types (7 types in sync)
Test Results: 1398/1398 passed, 0 failed
ESLint: 0 errors (1 pre-existing warning on sizer/sizer.js:2020, unrelated)
html-validate: clean
```

## Notes

- No release notes, no version bump (additive enrichment, same pattern as
  PR #256).
- Electricity price / annual cost is deliberately out of scope for this PR.
