### PR TITLE
Promote Private Path to GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.23.04] - 2026-08-28
+
+Private Path planning now reflects its Azure Local 2608 general availability for both hyperconverged and disaggregated deployments.
+
+### Changed
+
+- **Private Path promoted to GA** (`index.html`, `css/style.css`, `docs/outbound-connectivity/`) — removes Coming Soon signaling and documents the Azure Local 2608+, Arc Gateway, Azure Firewall Explicit Proxy, ExpressRoute or site-to-site VPN, VNet, subnet, routing, and TLS-inspection requirements.
+- **Private Path constraints made consistent** (`js/script.js`, `tests/index.html`) — both hyperconverged and disaggregated designs retain Private Path support and automatically require Arc Gateway plus Azure Firewall Explicit Proxy. Clouds where the Designer disables Arc Gateway can no longer select, resume, or import a contradictory Private Path state.
+- **Design outputs aligned with GA guidance** (`report/`, `docs/json-schema/odin-design.schema.json`) — HTML, Markdown, validation, and PowerPoint output identify Private Path as GA, include its 2608 and connectivity prerequisites, warn that TLS inspection and explicit-proxy certificates aren't supported, and publish the existing outbound values as a schema enum.
+
+---
+
 ## [0.23.03] - 2026-08-26
 
 Sizer now aligns GPU and AI/GitHub workload planning with current Microsoft Learn and GitHub Enterprise Server guidance, including explicit AKS infrastructure ownership.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">ODIN for Azure Local</h1>
 
-## Version 0.23.03 - Available here: https://aka.ms/ODIN
+## Version 0.23.04 - Available here: https://aka.ms/ODIN
 
 A browser-based planning toolkit for Azure Local (formerly Azure Stack HCI). ODIN combines architecture design, workload-based hardware sizing, storage planning, network and switch configuration, reference architectures, and deployment/report outputs. Configuration data is processed locally in the browser.
 
@@ -49,36 +49,16 @@ A browser-based planning toolkit for Azure Local (formerly Azure Stack HCI). ODI
 
 ## What's New
 
-### Version 0.23.03 - Latest Release
+### Version 0.23.04 - Latest Release
 
-> **Sizer now aligns GPU and AI/GitHub workload planning with current Microsoft Learn and GitHub Enterprise Server guidance, including explicit AKS infrastructure ownership.**
+> **Private Path planning now reflects Azure Local 2608 general availability for hyperconverged and disaggregated deployments.**
 
 **What's new**
-- **Model-dependent total GPU sizing** — Total VM mode accepts up to 252 GPUs for four-per-machine models such as L40S and 126 GPUs for two-per-machine models such as A2 across 63 N−1 effective machines (64 physical machines).
-- **Per-machine limits preserved** — Per-VM and other workload modes retain each model's supported GPUs-per-machine limit, and switching models clamps oversized values immediately.
-- **Instance-wide validation** — combined same-model workloads cannot exceed the selected GPU model's N−1 Azure Local instance capacity, and GPU totals drive machine recommendations; mixed models continue to produce the dedicated homogeneous-GPU conflict.
-- **Growth at the GPU ceiling** — Sizer removes and explains the automatic 10% growth allowance when it alone would exceed N−1 GPU capacity; manually selected growth remains unchanged and receives an actionable over-capacity warning.
-- **H100 removed** — NVIDIA H100 is no longer offered in Sizer hardware, DDA, or GPU-P choices and has been removed from the current public Sizer schema enum.
-- **Learn-aligned GPU support** — Arc VM DDA offers T4, A2, A16, L4, L40, L40S, and RTX Pro 6000; GPU-P offers A2, A10, A16, A40, L4, L40, L40S, and RTX Pro 6000. A100 is removed, and the same support applies to hyperconverged and disaggregated deployments.
-- **Right-sized GPU inventory** — automatically managed GPUs per machine are reconciled after machine scaling to preserve N−1 headroom without retaining unnecessary devices, including returning to zero after the final GPU workload is removed while preserving manual inventory.
-- **Stable scaling and reset behavior** — Agentic Retrieval production defaults select a compatible GPU and synchronize Hardware Configuration; topology/rack transitions settle without recursive reversal; disaggregated rack capacity is rechecked; and ALDO Reset re-enables all workload cards.
-- **Minimum-fit procurement guidance** — the first Sizing Note displays an amber "Advisory" label within the bold "Advisory - minimum-fit hardware" heading when configurations below 32 physical cores or 384 GB memory per machine are minimum-fit results rather than new-hardware procurement baselines.
-- **Single Node availability guidance** — Single Node results place a matching Advisory first, explaining that one machine has no live-migration or workload-failover destination and restart-requiring maintenance interrupts workloads.
-- **Sizing Notes in design documents** — Sizer recommendations now flow into Designer and appear in both HTML and PowerPoint cluster design documents.
-- **Design report fidelity** — reports use the "Azure Local Instance | Design Configuration Report" title, identify Designer-only or Sizer-and-Designer workflow inputs, include each workload's resolved GPU model and mode across document formats, match the Sizer's Advisory styling, and label GPU racks as "GPU Enabled."
-- **S2D guidance in design reports** — Single Node, standard, and rack-aware Sizer results show the recommended number of volumes and maximum supported size per volume, then carry the exact calculation and derivation through Designer into HTML, Word, Markdown, and PowerPoint.
-- **GPU instance totals** — Sizer-originated reports show the full NVIDIA model name per node and total physical GPU count across the instance.
-- **ToR configuration planning link** — Host Networking reports and the Physical Network Configuration PowerPoint slide link to the portable ToR Switch Configuration Generator & Validator for example Cisco and Dell configurations.
-- **Infrastructure IP Pool auto-ending** — entering a valid Starting IP in Designer automatically fills the minimum six-address Ending IP without overwriting a manual ending address, including after resume or import.
-- **Designer session and mobile reliability** — valid Infrastructure IP Pool edits persist for resume, while compact navigation and aligned breadcrumbs keep utility controls accessible on narrow mobile screens.
-- **Designer UI and report reliability** — completed SAN designs report architecture-aware selections without HCI-only false warnings; all report formats preserve workflow metadata, bounded Sizing Notes, and Advisory headings; the template picker is keyboard-operable; and the welcome screen identifies AI workloads in Sizer coverage.
-- **AMD Turin catalog coverage** — standard 5th Gen AMD EPYC sizing now includes the catalog-listed 84-core-per-socket option.
-- **Cluster-wide GPU-P planning** — Sizer rejects conflicting partition sizes across workloads and links hardware, DDA, GPU-P, and AKS controls to the relevant Microsoft Learn guidance.
-- **[No AKS double-counting](https://github.com/Azure/odinforazurelocal/issues/284)** — Foundry Local, Agentic Retrieval, and AI Video Indexer visibly include dedicated AKS Arc infrastructure; add the generic AKS workload only for another independent cluster. GitHub Enterprise Local runs as a GHES appliance VM, not on AKS.
-- **Learn-aligned AI sizing** — Foundry Local uses published minimum/recommended worker profiles and per-deployment model-cache storage, while Agentic Retrieval and Video Indexer no longer add undocumented overhead above their published worker requirements.
-- **Foundry Local model discovery** — the Worker Profile input links to Microsoft's current Foundry Local model catalog for compatible OSS model exploration without coupling model choice to a fixed sizing preset.
-- **GHES feature-aware sizing** — GitHub Enterprise Local defaults to one appliance VM, supports optional active/passive replicas, and adds the documented CPU/memory allowances for GitHub Actions and GitHub Code Security.
-- **Validation** — all **1,560 / 1,560** browser tests pass. Reusable Sizer and Designer real-UI validation matrices now complement the static suite for release candidates and relevant PRs, covering rendered-control transitions, synchronization, reset cleanup, outputs, handoffs, responsive layouts, and accessibility.
+- **Private Path is generally available** — Designer no longer labels ExpressRoute/VPN Private Path as Coming Soon.
+- **Both architecture paths supported** — Hyperconverged and Disaggregated designs can select Private Path, which requires Arc Gateway and Azure Firewall Explicit Proxy.
+- **GA prerequisites included** — Designer guidance and generated reports identify the Azure Local 2608+, ExpressRoute or site-to-site VPN, Azure networking, routing, proxy-bypass, and no-TLS-inspection requirements.
+- **Cloud state remains valid** — clouds where the Designer disables Arc Gateway cannot select, resume, or import Private Path.
+- **Current design outputs** — HTML, Markdown, validation, PowerPoint, and the public Designer JSON schema use the same GA semantics.
 
 ---
 
@@ -403,7 +383,7 @@ Published under [MIT License](/LICENSE). This project is provided as-is, without
 
 Built for the Azure Local community to simplify network architecture planning and deployment configuration.
 
-**Version**: 0.23.03<br>
+**Version**: 0.23.04<br>
 **Last Updated**: August 2026<br>
 **Compatibility**: Azure Local 2506+
 

--- a/css/style.css
+++ b/css/style.css
@@ -1007,37 +1007,6 @@ header .header-description {
     line-height: 1.5;
 }
 
-/* PRIVATE-PATH-PREVIEW: Remove this section when Private Path is GA */
-.coming-soon-badge {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
-    color: #000;
-    font-size: 0.65rem;
-    font-weight: 700;
-    padding: 4px 8px;
-    border-radius: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    z-index: 1;
-}
-
-.option-card.selected .coming-soon-badge {
-    right: 36px;
-}
-
-.option-card .preview-note {
-    margin-top: 0.75rem;
-    padding: 6px 10px;
-    background: rgba(245, 158, 11, 0.15);
-    border: 1px solid rgba(245, 158, 11, 0.3);
-    border-radius: 6px;
-    font-size: 0.75rem;
-    color: #fbbf24;
-    line-height: 1.4;
-}
-/* END PRIVATE-PATH-PREVIEW */
 
 /* DA1 storage-type Preview badge — iSCSI external SAN is in preview.
    Separate from .coming-soon-badge (still used by the private-path feature above). */

--- a/docs/json-schema/README.md
+++ b/docs/json-schema/README.md
@@ -25,7 +25,7 @@ Stable URLs (suitable for a `$schema` reference):
 
 ```jsonc
 {
-  "version": "0.23.03",            // metadata only — the producing app version; NOT validated
+  "version": "0.23.04",            // metadata only — the producing app version; NOT validated
   "exportedAt": "2026-08-05T10:00:00.000Z",
   "state": {
     "scenario": "connected",        // connected | disconnected | rackscale | m365local
@@ -122,7 +122,7 @@ autocomplete:
 ```jsonc
 {
   "$schema": "https://azure.github.io/odinforazurelocal/docs/json-schema/odin-design.schema.json",
-  "version": "0.23.03",
+  "version": "0.23.04",
   "state": { /* … */ }
 }
 ```

--- a/docs/json-schema/odin-design.schema.json
+++ b/docs/json-schema/odin-design.schema.json
@@ -230,7 +230,11 @@
         "intent": { "type": ["string", "null"], "description": "Network intent selection." },
         "customIntentConfirmed": { "type": "boolean" },
         "fqdnConfirmed": { "type": "boolean" },
-        "outbound": { "type": ["string", "null"], "description": "Outbound connectivity mode." },
+        "outbound": {
+          "type": ["string", "null"],
+          "enum": ["public", "private", "air_gapped", "limited", null],
+          "description": "Outbound connectivity mode. Private Path is supported for hyperconverged and disaggregated deployments on Azure Local 2608 or later and requires Arc Gateway plus Azure Firewall Explicit Proxy."
+        },
         "arc": { "type": ["string", "null"], "description": "Azure Arc connectivity mode." },
         "proxy": { "type": ["string", "object", "null"], "description": "Proxy configuration." },
         "ip": { "type": ["string", "null"], "description": "IP allocation mode." },

--- a/docs/module-planning/complete/private-path-ga-plan.md
+++ b/docs/module-planning/complete/private-path-ga-plan.md
@@ -1,0 +1,37 @@
+# Private Path GA
+
+## Current state
+
+- Designer exposes Private Path for connected hyperconverged and disaggregated deployments and already forces Arc Gateway plus Azure Firewall Explicit Proxy.
+- Private Path is still labelled Coming Soon in Designer and the outbound-connectivity guide.
+- Proxy/TLS-inspection and bypass guidance exists, but GA version prerequisites and current deployment links are incomplete.
+- Azure Government disables Arc Gateway, while a later Private Path rule can restore it and create contradictory state.
+
+## Proposed change
+
+- Promote Private Path to GA without changing the persisted `outbound: "private"` contract.
+- Keep Private Path available for both hyperconverged and disaggregated deployments.
+- Require Azure Local 2608+, Arc Gateway, Azure Firewall Explicit Proxy, and ExpressRoute or site-to-site VPN in UI/report guidance.
+- Prevent Private Path selection where the Designer disables Arc Gateway, including stale imported or restored state.
+- Remove preview-only markup/styles and update links to the 2608 Private Path documentation.
+- Add regression coverage for both supported architectures and cloud constraints.
+
+## Files touched
+
+- `index.html`, `css/style.css`, `js/script.js`
+- `docs/outbound-connectivity/index.html`, `docs/outbound-connectivity/styles.css`
+- `report/report.js`, `report/pptx-export.js`
+- `docs/json-schema/odin-design.schema.json`, `tests/index.html`
+- Release/version documentation
+
+## Open questions
+
+- Public Learn currently labels the Private Path article as applying to hyperconverged deployments; implementation follows the confirmed product support for both hyperconverged and disaggregated deployments.
+- Azure Government remains unavailable while the Designer's Arc Gateway support rule disables that service.
+
+## Implementation order
+
+1. Remove preview markers and add GA prerequisite guidance.
+2. Make Private Path and Arc Gateway cloud constraints settle consistently.
+3. Update report/PPTX guidance, schemas, tests, and release notes.
+4. Run static validation and real-UI smoke paths for both architectures and the inverse cloud transition.

--- a/docs/outbound-connectivity/index.html
+++ b/docs/outbound-connectivity/index.html
@@ -110,23 +110,21 @@
                         </ul>
                     </div>
                 </div>
-                <!-- PRIVATE-PATH-PREVIEW: Remove this comment and the preview-banner div when Private Path is GA -->
                 <div class="arch-card private">
-                    <div class="preview-banner private-path-preview">
-                        <span class="preview-icon">🚧</span>
-                        <span><strong>Coming Soon:</strong> Private Path is an upcoming feature not yet supported. Documentation is provided for planning purposes.</span>
-                    </div>
                     <div class="arch-header">
                         <h3>🔐 Private Path</h3>
-                        <span class="badge">Enhanced Security</span>
+                        <span class="badge">Generally Available</span>
                     </div>
                     <div class="arch-body">
                         <p>Traffic routes through Arc Gateway via <strong>ExpressRoute or Site-to-Site VPN</strong>.</p>
                         <ul>
+                            <li>Azure Local 2608 or later</li>
+                            <li>Hyperconverged and disaggregated deployments</li>
                             <li>Azure Firewall Explicit Proxy</li>
                             <li>No public internet exposure</li>
                             <li>Private connectivity to Azure</li>
                         </ul>
+                        <a href="https://learn.microsoft.com/en-us/azure/azure-local/deploy/deployment-with-azure-arc-gateway-private-path?view=azloc-2608" target="_blank" rel="noopener noreferrer">Private Path prerequisites and registration ↗</a>
                     </div>
                 </div>
             </div>
@@ -1235,6 +1233,20 @@
         <!-- Configuration Section -->
         <section id="configuration" class="section">
             <h2>Configuration</h2>
+
+            <h3>Private Path Prerequisites</h3>
+            <div class="config-section">
+                <ul class="config-list">
+                    <li>Azure Local software version 2608 or later</li>
+                    <li>An existing Azure virtual network with Azure Arc Private Link Scope disabled</li>
+                    <li>A workload subnet and an <code>AzureFirewallSubnet</code> of at least <code>/26</code></li>
+                    <li>Azure Firewall Standard or Premium with Explicit Proxy enabled</li>
+                    <li>Existing ExpressRoute or site-to-site VPN connectivity and routing to the Azure Firewall private IP</li>
+                    <li>An Azure Arc gateway in the same subscription where the Azure Local machines are registered</li>
+                </ul>
+                <p><strong>Important:</strong> TLS inspection and certificates on Azure Firewall Explicit Proxy aren't supported. Microsoft supports only the documented Private Path architecture.</p>
+                <a href="https://learn.microsoft.com/en-us/azure/azure-local/deploy/deployment-with-azure-arc-gateway-private-path?view=azloc-2608" target="_blank" rel="noopener noreferrer" class="doc-link">📖 Private Path deployment guidance ↗</a>
+            </div>
 
             <h3>Proxy Bypass Requirements</h3>
             <p>When defining your proxy bypass string for Arc initialization or the Companion App, include:</p>

--- a/docs/outbound-connectivity/styles.css
+++ b/docs/outbound-connectivity/styles.css
@@ -20,29 +20,6 @@
     --subtle-bg-hover: rgba(255, 255, 255, 0.06);
 }
 
-/* PRIVATE-PATH-PREVIEW: Remove this section when Private Path is GA */
-.preview-banner {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 14px 18px;
-    background: linear-gradient(135deg, rgba(245, 158, 11, 0.15) 0%, rgba(217, 119, 6, 0.1) 100%);
-    border: 1px solid rgba(245, 158, 11, 0.4);
-    border-radius: 8px;
-    margin-bottom: 16px;
-    font-size: 0.9rem;
-    color: #fbbf24;
-    line-height: 1.5;
-}
-
-.preview-banner .preview-icon {
-    font-size: 1.4rem;
-}
-
-.preview-banner strong {
-    color: #f59e0b;
-}
-/* END PRIVATE-PATH-PREVIEW */
 
 /* ===========================================
    Top Tab Navigation (consistent with main site)

--- a/docs/version-history/README.md
+++ b/docs/version-history/README.md
@@ -6,6 +6,17 @@ Return to the [ODIN README](../../README.md).
 
 ### Version 0.23.x Series (August 2026)
 
+#### 0.23.03 - GPU, AI workload, and design-report alignment
+
+> Sizer aligned GPU and AI/GitHub workload planning with current Microsoft Learn and GitHub Enterprise Server guidance, including explicit AKS infrastructure ownership.
+
+- Added model-dependent total GPU sizing, N−1 instance limits, growth reconciliation, and final physical GPU inventory reconciliation.
+- Aligned DDA and GPU-P model support, removed H100 and A100 where unsupported, and enforced cluster-wide GPU-P partition consistency.
+- Clarified included AKS infrastructure for Foundry Local, Agentic Retrieval, and AI Video Indexer while keeping GitHub Enterprise Local as a standalone appliance VM.
+- Carried bounded Sizing Notes, GPU metadata, S2D volume calculations, workflow provenance, and ToR planning guidance into design reports and PowerPoint.
+- Stabilized Sizer transitions and reset behavior, improved Designer report fidelity and mobile session behavior, and added integrated real-UI release-validation skills.
+- All **1,560 / 1,560** browser tests passed.
+
 #### 0.23.02 - Agentic Retrieval sizing and dependency audit fixes
 
 > Agentic Retrieval sizing follows the current Foundry Local requirements with explicit deployment modes and language-model endpoint capacity.

--- a/index.html
+++ b/index.html
@@ -2031,9 +2031,7 @@
                             <h3>Public Internet</h3>
                             <p>Direct connectivity to cloud endpoints.</p>
                         </div>
-                        <!-- PRIVATE-PATH-PREVIEW: Remove this comment and the coming-soon-badge span when Private Path is GA -->
                         <div class="option-card" data-value="private" onclick="selectOption('outbound', 'private')">
-                            <span class="coming-soon-badge private-path-preview">Coming Soon</span>
                             <div class="icon">
                                 <svg aria-hidden="true" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor">
                                     <path d="M4 12L20 12" stroke-width="1.5" />
@@ -2043,9 +2041,14 @@
                                 </svg>
                             </div>
                             <h3>ExpressRoute / VPN</h3>
-                            <p>Private connectivity.</p>
-                            <p class="preview-note private-path-preview">⚠️ Feature not available yet</p>
+                            <p>Private Path connectivity for Azure Local 2608 or later.</p>
                         </div>
+                    </div>
+
+                    <div id="private-path-ga-info" class="info-box" style="margin-top: 1.5rem;">
+                        <strong style="color: var(--accent-blue);">Private Path requirements</strong>
+                        <p style="margin-top: 0.5rem;">Private Path is supported for hyperconverged and disaggregated deployments running Azure Local 2608 or later. It requires an Azure Arc gateway, Azure Firewall Explicit Proxy, and existing ExpressRoute or site-to-site VPN connectivity.</p>
+                        <p><a href="https://learn.microsoft.com/en-us/azure/azure-local/deploy/deployment-with-azure-arc-gateway-private-path?view=azloc-2608" target="_blank" rel="noopener noreferrer" style="color: var(--accent-blue); text-decoration: underline;">Review Private Path prerequisites and registration</a></p>
                     </div>
 
                     <!-- Disconnected Options -->
@@ -2156,8 +2159,8 @@
                                 target="_blank" style="color:var(--accent-blue); text-decoration:underline;">Read
                                 documentation</a>
                         </p>
-                        <p>Azure Local doesn't support HTTPS inspection. Make sure that HTTPS inspection is disabled along your networking path for Azure Local required endpoints to prevent any connectivity errors. This includes use of Entra ID tenant restrictions v1 which isn't supported for Azure Local management network communication.
-                            <br><a href="https://learn.microsoft.com/en-us/azure/azure-local/concepts/firewall-requirements?view=azloc-2511" target="_blank" style="color:var(--accent-blue); text-decoration:underline;">Review the required firewall endpoints</a>
+                        <p>Azure Local doesn't support HTTPS inspection. Make sure that HTTPS inspection is disabled along your networking path for Azure Local required endpoints to prevent any connectivity errors. Azure Firewall Explicit Proxy certificates aren't supported for Private Path. This includes use of Entra ID tenant restrictions v1 which isn't supported for Azure Local management network communication.
+                            <br><a href="https://learn.microsoft.com/en-us/azure/azure-local/concepts/private-path-network-overview?view=azloc-2608" target="_blank" style="color:var(--accent-blue); text-decoration:underline;">Review Private Path restrictions and traffic flows</a>
                         </p>
                     </div>
                 </section>

--- a/js/changelog.js
+++ b/js/changelog.js
@@ -53,6 +53,18 @@ function showChangelog() { // eslint-disable-line no-unused-vars
 
             <div style="color: var(--text-primary); line-height: 1.8;">
                 <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
+                    <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.23.04</h4>
+                    <div style="font-size: 13px; color: var(--text-secondary);">August 28, 2026</div>
+                    <p style="margin: 8px 0 0 0; font-size: 13px; color: var(--text-secondary);">Private Path planning now reflects Azure Local 2608 general availability for hyperconverged and disaggregated deployments.</p>
+                    <ul style="margin: 8px 0 0 0; padding-left: 20px; font-size: 13px; color: var(--text-secondary);">
+                        <li><strong>Generally available</strong> &mdash; Designer no longer labels ExpressRoute/VPN Private Path as Coming Soon.</li>
+                        <li><strong>Both architecture paths</strong> &mdash; Hyperconverged and Disaggregated designs support Private Path with required Arc Gateway and Azure Firewall Explicit Proxy.</li>
+                        <li><strong>GA prerequisites</strong> &mdash; Designer guidance and reports include Azure Local 2608+, ExpressRoute or site-to-site VPN, Azure networking, proxy bypass, and no-TLS-inspection requirements.</li>
+                        <li><strong>Consistent cloud constraints</strong> &mdash; clouds where the Designer disables Arc Gateway cannot select, resume, or import Private Path.</li>
+                        <li><strong>Output alignment</strong> &mdash; HTML, Markdown, validation, PowerPoint, and the public Designer JSON schema use the same GA semantics.</li>
+                    </ul>
+                </div>
+                <div style="margin-bottom: 24px; padding: 16px; background: rgba(59, 130, 246, 0.1); border-left: 4px solid var(--accent-blue); border-radius: 4px;">
                     <h4 style="margin: 0 0 8px 0; color: var(--accent-blue);">Version 0.23.03</h4>
                     <div style="font-size: 13px; color: var(--text-secondary);">August 26, 2026</div>
                     <p style="margin: 8px 0 0 0; font-size: 13px; color: var(--text-secondary);">Sizer now aligns GPU and AI/GitHub workload planning with current Microsoft Learn and GitHub Enterprise Server guidance, including explicit AKS infrastructure ownership.</p>

--- a/js/script.js
+++ b/js/script.js
@@ -456,6 +456,20 @@ function getInitialWizardState() {
 
 const state = getInitialWizardState();
 
+function isPrivatePathAvailableForRegion(region) {
+    return region !== 'azure_government' && region !== 'azure_china';
+}
+
+function clearUnsupportedPrivatePath(target) {
+    if (!target || target.outbound !== 'private' || isPrivatePathAvailableForRegion(target.region)) return false;
+    target.outbound = null;
+    target.arc = null;
+    target.proxy = null;
+    target.privateEndpoints = null;
+    target.privateEndpointsList = [];
+    return true;
+}
+
 // Auto-save state to localStorage
 function saveStateToLocalStorage() {
     try {
@@ -482,6 +496,7 @@ function loadStateFromLocalStorage() {
             // iSCSI 4-NIC was retired in v0.22.70 (build 2607 ships 6-NIC iSCSI
             // only). Remap any resumed session to the supported 6-NIC layout.
             if (parsed.data.disaggStorageType === 'iscsi_4nic') parsed.data.disaggStorageType = 'iscsi_6nic';
+            clearUnsupportedPrivatePath(parsed.data);
             return parsed;
         }
         return null;
@@ -2849,6 +2864,11 @@ function generateReport() {
 }
 
 function selectOption(category, value) {
+    if (category === 'outbound' && value === 'private' && !isPrivatePathAvailableForRegion(state.region)) {
+        showToast('Private Path requires Arc Gateway, which is unavailable for the selected Azure cloud.', 'warning');
+        return;
+    }
+
     // Special handling for Microsoft 365 Local - stop workflow and show documentation
     if (category === 'scenario' && value === 'm365local') {
         // Hide Multi-Rack message when switching to Microsoft 365 Local
@@ -2971,6 +2991,11 @@ function selectOption(category, value) {
         state.ports = null;
         state.storage = null;
         state.intent = null;
+        state.outbound = null;
+        state.arc = null;
+        state.proxy = null;
+        state.privateEndpoints = null;
+        state.privateEndpointsList = [];
         state.disaggStorageType = null;
         state.disaggBackupEnabled = false;
         state.disaggPortCount = null;
@@ -4171,14 +4196,23 @@ function updateUI() {
         // Outbound visibility logic (Step 7) moved later or handled here?
         const outboundConnected = document.getElementById('outbound-connected');
         const outboundDisconnected = document.getElementById('outbound-disconnected');
+        const privatePathGaInfo = document.getElementById('private-path-ga-info');
 
         // Disconnected scenario forces Step 7 options
         if (state.scenario === 'disconnected') {
             if (outboundConnected) outboundConnected.classList.add('hidden');
             if (outboundDisconnected) outboundDisconnected.classList.remove('hidden');
+            if (privatePathGaInfo) {
+                privatePathGaInfo.classList.add('hidden');
+                privatePathGaInfo.classList.remove('visible');
+            }
         } else {
             if (outboundConnected) outboundConnected.classList.remove('hidden');
             if (outboundDisconnected) outboundDisconnected.classList.add('hidden');
+            if (privatePathGaInfo) {
+                privatePathGaInfo.classList.remove('hidden');
+                privatePathGaInfo.classList.add('visible');
+            }
         }
 
         // Single-node clusters: Hide storage switched/switchless options but show ToR switch selection
@@ -4399,6 +4433,10 @@ function updateUI() {
         arc: {
             'arc_gateway': document.querySelector('[data-value="arc_gateway"]'),
             'no_arc': document.querySelector('[data-value="no_arc"]')
+        },
+        outbound: {
+            'public': document.querySelector('[data-value="public"][onclick*="outbound"]'),
+            'private': document.querySelector('[data-value="private"][onclick*="outbound"]')
         },
         proxy: {
             'proxy': document.querySelector('[data-value="proxy"]'),
@@ -4833,6 +4871,16 @@ function updateUI() {
     if (state.region === 'azure_government') {
         cards.arc['arc_gateway'].classList.add('disabled');
         if (state.arc === 'arc_gateway') state.arc = null;
+        if (cards.outbound.private) {
+            cards.outbound.private.classList.add('disabled');
+            cards.outbound.private.classList.remove('selected');
+            cards.outbound.private.title = 'Private Path requires Arc Gateway, which is unavailable for Azure Government in this Designer.';
+        }
+        clearUnsupportedPrivatePath(state);
+        cards.arc.arc_gateway.classList.remove('selected');
+        cards.proxy.proxy.classList.remove('selected');
+    } else if (cards.outbound.private) {
+        cards.outbound.private.title = '';
     }
 
     // Step 9b -> Step 10 (IP): Depends on privateEndpoints selection
@@ -9498,6 +9546,12 @@ function prepareDesignerImport(imported) {
         return {
             ok: false,
             message: 'This Designer configuration uses an unsupported architecture and was not imported.'
+        };
+    }
+    if (candidate.outbound === 'private' && !isPrivatePathAvailableForRegion(candidate.region)) {
+        return {
+            ok: false,
+            message: 'This Designer configuration uses Private Path in an Azure cloud where Arc Gateway is unavailable.'
         };
     }
     if (!Array.isArray(candidate.sdnFeatures) || !Array.isArray(candidate.dnsServers) ||

--- a/js/version.js
+++ b/js/version.js
@@ -1,2 +1,2 @@
 // Shared ODIN application release version. SIZER_VERSION remains independent.
-globalThis.ODIN_VERSION = '0.23.03';
+globalThis.ODIN_VERSION = '0.23.04';

--- a/report/pptx-export.js
+++ b/report/pptx-export.js
@@ -1272,7 +1272,7 @@
 
         const bullets = [];
 
-        const outboundLabel = s.outbound === 'private' ? 'Private (controlled egress via firewall/proxy)'
+        const outboundLabel = s.outbound === 'private' ? 'Private Path (ExpressRoute or site-to-site VPN)'
             : s.outbound === 'public' ? 'Public (direct, allow-listed)'
                 : (s.outbound || 'n/a');
         bullets.push({ text: 'Outbound: ' + outboundLabel, lvl: 1 });
@@ -1317,6 +1317,10 @@
 
         // Planning notes that mirror the validation report.
         bullets.push({ text: 'Configure proxy on WinINET, WinHTTP and HTTP_PROXY/HTTPS_PROXY env vars consistently before Arc registration.', lvl: 1 });
+        if (s.outbound === 'private') {
+            bullets.push({ text: 'Requires Azure Local 2608+, Arc Gateway, and Azure Firewall Explicit Proxy; supported for hyperconverged and disaggregated deployments.', lvl: 1 });
+            bullets.push({ text: 'TLS inspection and certificates on Azure Firewall Explicit Proxy are not supported.', lvl: 1 });
+        }
         if (s.arc === 'arc_gateway') {
             bullets.push({ text: 'Arc Gateway tunnels OS HTTPS to Microsoft endpoints; non-Microsoft HTTPS and OS HTTP still traverse the enterprise proxy.', lvl: 1 });
         }

--- a/report/report.js
+++ b/report/report.js
@@ -1676,9 +1676,11 @@
         }
         const outboundNotes = [];
         if (s.outbound === 'private') {
-            outboundNotes.push('Private outbound assumes controlled egress via firewall/proxy; the wizard forces Arc Gateway + explicit proxy behavior.');
+            outboundNotes.push('Private Path is generally available for hyperconverged and disaggregated deployments running Azure Local 2608 or later.');
+            outboundNotes.push('Private Path requires ExpressRoute or site-to-site VPN, Arc Gateway, and Azure Firewall Explicit Proxy.');
             outboundNotes.push('With Arc Gateway, the node-side Arc proxy establishes a secure HTTPS tunnel to an Azure-hosted Arc Gateway public endpoint.');
             outboundNotes.push('Proxy bypass lists need to include node IPs, cluster IP, and infrastructure IPs/subnet.');
+            outboundNotes.push('TLS inspection and certificates on Azure Firewall Explicit Proxy are not supported.');
         } else if (s.outbound === 'public') {
             outboundNotes.push('Public outbound allows direct access to required endpoints (subject to firewall allow-listing).');
         }
@@ -7100,11 +7102,13 @@
         // Outbound / Arc / Proxy
         const outboundNotes = [];
         if (s.outbound === 'private') {
-            outboundNotes.push('Private outbound assumes controlled egress (for example, via your firewall/proxy) and the wizard forces Arc Gateway + explicit proxy behavior.');
+            outboundNotes.push('Private Path is generally available for hyperconverged and disaggregated deployments running Azure Local 2608 or later.');
+            outboundNotes.push('Private Path requires ExpressRoute or site-to-site VPN, Arc Gateway, and Azure Firewall Explicit Proxy.');
             outboundNotes.push('With Arc Gateway, the node-side Arc proxy establishes a secure HTTPS tunnel to an Azure-hosted Arc Gateway public endpoint, which reduces the number of outbound destinations you typically need to allow compared to managing many individual Azure service endpoints.');
             outboundNotes.push('Not all traffic types are handled the same way: OS HTTPS traffic intended for Microsoft-managed endpoints can be routed via Arc proxy; OS HTTP and non-Microsoft HTTPS traffic typically must traverse your enterprise proxy/firewall based on your organization\'s allowlists.');
             outboundNotes.push('Implementation note: proxy bypass lists usually need to include at least the node IPs, cluster IP, and the infrastructure IPs/subnet so internal cluster traffic (and infrastructure services) do not get forced through the proxy path.');
             outboundNotes.push('Proxy planning note: Azure Local guidance emphasizes configuring proxy settings before registering nodes to Azure Arc, and keeping proxy configuration consistent across OS proxy components (WinINET, WinHTTP, and environment variables).');
+            outboundNotes.push('TLS inspection and certificates on Azure Firewall Explicit Proxy are not supported.');
         } else if (s.outbound === 'public') {
             outboundNotes.push('Public outbound allows direct access to required endpoints (subject to firewall allow-listing).');
             outboundNotes.push('Even with public outbound, Arc-related components still require outbound HTTPS to Microsoft endpoints; ensure your firewall policy allows the required destinations.');
@@ -7440,6 +7444,7 @@
 
         // Additional official references (not in wizard UI but still Microsoft Learn)
         const REF_AZLOC_PREREQS = 'https://learn.microsoft.com/en-us/azure/azure-local/deploy/deployment-prerequisites?view=azloc-2511';
+        const REF_AZLOC_PRIVATE_PATH = 'https://learn.microsoft.com/en-us/azure/azure-local/deploy/deployment-with-azure-arc-gateway-private-path?view=azloc-2608';
         const REF_AZLOC_AD_PREP = 'https://learn.microsoft.com/en-us/azure/azure-local/deploy/deployment-prep-active-directory?view=azloc-2511';
         const REF_AZLOC_LOCAL_ID = 'https://learn.microsoft.com/en-us/azure/azure-local/deploy/deployment-local-identity-with-key-vault?view=azloc-2511';
         const REF_ARC_GATEWAY = 'https://learn.microsoft.com/en-us/azure/azure-arc/servers/arc-gateway';
@@ -7635,8 +7640,9 @@
         // Outbound -> arc + proxy
         add('Outbound', 'Outbound selected', !!s.outbound, s.outbound ? ('Selected: ' + formatOutbound(s.outbound)) : '');
         if (s.outbound === 'private') {
-            add('Outbound', 'Private outbound forces Arc Gateway', s.arc === 'arc_gateway', 'Private outbound assumes controlled egress; the wizard forces Arc Gateway so outbound Arc traffic is routed through a secured tunnel to the Arc Gateway public endpoint, reducing the number of outbound destinations you typically need to allow.', [REF_ARC_GATEWAY, REF_ARC_GATEWAY_DEEPDIVE, REF_AZLOC_FIREWALL]);
-            add('Outbound', 'Private outbound forces Proxy enabled', s.proxy === 'proxy', 'Private outbound requires explicit proxy behavior in the wizard. OS HTTP traffic and non-approved HTTPS destinations generally need to be handled by your enterprise proxy/firewall policy, while Arc proxy routes approved Microsoft-managed HTTPS endpoints through the Arc Gateway tunnel.', [REF_ARC_GATEWAY_DEEPDIVE, REF_AZLOC_FIREWALL, REF_AZLOC_PREREQS]);
+            add('Outbound', 'Private Path architecture is supported', s.architecture === 'hyperconverged' || s.architecture === 'disaggregated', 'Private Path is generally available for hyperconverged and disaggregated deployments running Azure Local 2608 or later.', [REF_AZLOC_PRIVATE_PATH]);
+            add('Outbound', 'Private Path forces Arc Gateway', s.arc === 'arc_gateway', 'Private Path requires Arc Gateway so approved Microsoft-managed HTTPS traffic can use the Arc Gateway tunnel.', [REF_AZLOC_PRIVATE_PATH, REF_ARC_GATEWAY]);
+            add('Outbound', 'Private Path forces Azure Firewall Explicit Proxy', s.proxy === 'proxy', 'Private Path requires Azure Firewall Explicit Proxy over existing ExpressRoute or site-to-site VPN connectivity. TLS inspection and explicit-proxy certificates are not supported.', [REF_AZLOC_PRIVATE_PATH]);
         }
 
         // Azure Gov constraint

--- a/tests/index.html
+++ b/tests/index.html
@@ -462,16 +462,16 @@
                 const logo = branding.querySelector('img');
                 const button = branding.querySelector('button');
                 return assert(
-                    globalThis.ODIN_VERSION === '0.23.03'
+                    globalThis.ODIN_VERSION === '0.23.04'
                         && WIZARD_VERSION === globalThis.ODIN_VERSION
                         && logo.getAttribute('src') === '../images/odin-logo.png'
                         && brandings[1].querySelector('img').getAttribute('src') === 'images/odin-logo.png'
                         && brandings[2].querySelector('img').getAttribute('src') === 'images/odin-logo.png'
                         && host.querySelectorAll('#odin-logo').length === 1
-                        && branding.textContent.includes('Version 0.23.03')
+                        && branding.textContent.includes('Version 0.23.04')
                         && button.textContent === "What's New",
                     'shared branding renders relative assets, rejects external base URLs, and assigns one primary logo ID',
-                    '0.23.03 / ../images/odin-logo.png / two local fallbacks / one primary ID / What\'s New',
+                    '0.23.04 / ../images/odin-logo.png / two local fallbacks / one primary ID / What\'s New',
                     `${globalThis.ODIN_VERSION} / ${logo.getAttribute('src')} / ${brandings[1].querySelector('img').getAttribute('src')} / ${brandings[2].querySelector('img').getAttribute('src')} / ${host.querySelectorAll('#odin-logo').length} primary ID / ${button.textContent}`);
             })()
         ]);
@@ -955,6 +955,50 @@
                 'Air Gapped', 'Air Gapped', formatOutbound('air_gapped')),
             assert(formatOutbound('limited') === 'Limited Connectivity', 
                 'Limited', 'Limited Connectivity', formatOutbound('limited'))
+        ]);
+
+        testSuite('Private Path GA constraints', 'script.js', [
+            (function() {
+                const original = JSON.parse(JSON.stringify(state));
+                state.region = 'azure_commercial';
+                state.architecture = 'hyperconverged';
+                selectOption('outbound', 'private');
+                const result = state.outbound === 'private' && state.arc === 'arc_gateway' && state.proxy === 'proxy';
+                Object.keys(state).forEach(key => delete state[key]);
+                Object.assign(state, original);
+                return assert(result, 'Hyperconverged supports Private Path and forces Arc Gateway + explicit proxy', true, result);
+            })(),
+            (function() {
+                const original = JSON.parse(JSON.stringify(state));
+                state.region = 'azure_commercial';
+                state.architecture = 'disaggregated';
+                selectOption('outbound', 'private');
+                const result = state.outbound === 'private' && state.arc === 'arc_gateway' && state.proxy === 'proxy';
+                Object.keys(state).forEach(key => delete state[key]);
+                Object.assign(state, original);
+                return assert(result, 'Disaggregated supports Private Path and forces Arc Gateway + explicit proxy', true, result);
+            })(),
+            (function() {
+                const candidate = { region: 'azure_government', outbound: 'private', arc: 'arc_gateway', proxy: 'proxy', privateEndpoints: 'pe_enabled', privateEndpointsList: ['keyvault'] };
+                const changed = clearUnsupportedPrivatePath(candidate);
+                const result = changed && candidate.outbound === null && candidate.arc === null && candidate.proxy === null && candidate.privateEndpoints === null && candidate.privateEndpointsList.length === 0;
+                return assert(result, 'Unsupported cloud clears stale Private Path dependencies', true, result);
+            })(),
+            (function() {
+                const prepared = prepareDesignerImport({
+                    version: WIZARD_VERSION,
+                    state: Object.assign(getInitialWizardState(), {
+                        scenario: 'connected',
+                        architecture: 'hyperconverged',
+                        region: 'azure_government',
+                        outbound: 'private',
+                        arc: 'arc_gateway',
+                        proxy: 'proxy'
+                    })
+                });
+                return assert(prepared.ok === false && /Arc Gateway is unavailable/.test(prepared.message),
+                    'Import rejects Private Path where Arc Gateway is unavailable', false, prepared.ok);
+            })()
         ]);
 
         // Test: getProxyLabel


### PR DESCRIPTION
## Summary

- promote Azure Local Private Path from preview to generally available for Hyperconverged and Disaggregated architectures
- require Azure Local 2608+, Arc Gateway, Azure Firewall Explicit Proxy, and ExpressRoute or site-to-site VPN guidance
- prevent unsupported Azure Government, imported, and restored Private Path states from producing contradictory selections
- update Designer UI, connectivity guidance, reports, PowerPoint output, JSON schema, tests, and release metadata for version 0.23.04

## Validation

- `npm run lint:js` (passes with two pre-existing indentation warnings)
- `npm run lint:html`
- `npm run lint:css`
- `node scripts/run-tests.js` — 1,564/1,564 passed
- `node scripts/smoke-test-pptx.js`
- focused disaggregated FC SAN PowerPoint generation scenario — passed, 10,154,054-byte deck
- `git diff --check`
- planning-note privacy scan — zero hits

### Designer UI

- Hyperconverged Private Path selection forces Arc Gateway and Azure Firewall Explicit Proxy
- Disaggregated Private Path remains available and enforces the same dependencies
- switching to Azure Government disables Private Path and clears stale Private Path, Arc Gateway, and proxy state
- returning to Azure Commercial restores Private Path availability
- GA prerequisite guidance and proxy TLS/certificate warning render correctly
- modified UI checked at mobile width and in light/dark themes
- no page errors or failed same-origin requests

### Release matrices

- Designer release paths covered: Connected Hyperconverged, Connected Disaggregated, disconnected management, disconnected workload, rack-aware HCI, Multi-Rack stop-flow, and Microsoft 365 Local stop-flow
- Sizer release validation covered deployment/workload scaling, scale-down, GPU/growth boundaries, reset, and multi-instance behavior

## Notes

- persisted Designer contract remains `outbound: "private"`
- no breaking schema envelope change
